### PR TITLE
Ci/use linux runners for android tests

### DIFF
--- a/.github/workflows/runtime_bridge_integration_tests.yml
+++ b/.github/workflows/runtime_bridge_integration_tests.yml
@@ -49,7 +49,7 @@ jobs:
         run: cd packages/enmeshed_runtime_bridge && flutter test integration_test/suite_test.dart --dart-define=app_baseUrl=${{secrets.CNS_NMSHD_TEST_BASEURL}} --dart-define=app_clientId=${{secrets.CNS_NMSHD_TEST_CLIENTID}} --dart-define=app_clientSecret=${{secrets.CNS_NMSHD_TEST_CLIENTSECRET}}
 
   android:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Setup Java
@@ -66,6 +66,11 @@ jobs:
         run: |
           dart pub global activate melos
           melos bootstrap
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: Start emulator and run tests
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/.github/workflows/runtime_bridge_integration_tests.yml
+++ b/.github/workflows/runtime_bridge_integration_tests.yml
@@ -50,9 +50,6 @@ jobs:
 
   android:
     runs-on: macos-latest
-    env:
-      api-level: 32
-      target: playstore
     steps:
       - uses: actions/checkout@v4
       - name: Setup Java
@@ -72,8 +69,8 @@ jobs:
       - name: Start emulator and run tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          target: ${{ env.target }}
-          api-level: ${{ env.api-level }}
+          target: playstore
+          api-level: 32
           force-avd-creation: false
           avd-name: integration_test
           disable-spellchecker: true


### PR DESCRIPTION
GH [announced hardware acceleration for android emulators](https://github.blog/changelog/2024-04-02-github-actions-hardware-accelerated-android-virtualization-now-available/) and the action we are using [supports and recommends](https://github.com/reactivecircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners) this.