### PR TITLE
Refactor/remove custom toStrings

### DIFF
--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/affiliation.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/affiliation.dart
@@ -21,8 +21,5 @@ class AffiliationAttributeValue extends IdentityAttributeValue {
   Map<String, dynamic> toJson() => {'@type': super.atType, 'role': role, 'organization': organization, 'unit': unit};
 
   @override
-  String toString() => 'AffiliationAttributeValue(role: $role, organization: $organization, unit: $unit)';
-
-  @override
   List<Object?> get props => [role, organization, unit];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/affiliation_organization.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/affiliation_organization.dart
@@ -15,8 +15,5 @@ class AffiliationOrganizationAttributeValue extends IdentityAttributeValue {
   Map<String, dynamic> toJson() => {'@type': super.atType, 'value': value};
 
   @override
-  String toString() => 'AffiliationOrganizationAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/affiliation_role.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/affiliation_role.dart
@@ -15,8 +15,5 @@ class AffiliationRoleAttributeValue extends IdentityAttributeValue {
   Map<String, dynamic> toJson() => {'@type': super.atType, 'value': value};
 
   @override
-  String toString() => 'AffiliationRoleAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/affiliation_unit.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/affiliation_unit.dart
@@ -13,8 +13,5 @@ class AffiliationUnitAttributeValue extends IdentityAttributeValue {
   Map<String, dynamic> toJson() => {'@type': super.atType, 'value': value};
 
   @override
-  String toString() => 'AffiliationUnitAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/birth_city.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/birth_city.dart
@@ -18,8 +18,5 @@ class BirthCityAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'BirthCityAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/birth_country.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/birth_country.dart
@@ -18,8 +18,5 @@ class BirthCountryAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'BirthCountryAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/birth_date.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/birth_date.dart
@@ -26,8 +26,5 @@ class BirthDateAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'BirthDateAttributeValue(day: $day, month: $month, year: $year)';
-
-  @override
   List<Object?> get props => [day, month, year];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/birth_day.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/birth_day.dart
@@ -18,8 +18,5 @@ class BirthDayAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'BirthDayAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/birth_month.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/birth_month.dart
@@ -18,8 +18,5 @@ class BirthMonthAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'BirthMonthAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/birth_name.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/birth_name.dart
@@ -18,8 +18,5 @@ class BirthNameAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'BirthNameAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/birth_place.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/birth_place.dart
@@ -26,8 +26,5 @@ class BirthPlaceAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'BirthPlaceAttributeValue(city: $city, country: $country, state: $state)';
-
-  @override
   List<Object?> get props => [city, country, state];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/birth_state.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/birth_state.dart
@@ -18,8 +18,5 @@ class BirthStateAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'BirthStateAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/birth_year.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/birth_year.dart
@@ -18,8 +18,5 @@ class BirthYearAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'BirthYearAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/citizenship.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/citizenship.dart
@@ -18,8 +18,5 @@ class CitizenshipAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'CitizenshipAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/city.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/city.dart
@@ -18,8 +18,5 @@ class CityAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'CityAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/communication_language.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/communication_language.dart
@@ -18,8 +18,5 @@ class CommunicationLanguageAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'CommunicationLanguageAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/country.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/country.dart
@@ -18,8 +18,5 @@ class CountryAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'CountryAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/delivery_box_address.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/delivery_box_address.dart
@@ -46,10 +46,5 @@ class DeliveryBoxAddressAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() {
-    return 'DeliveryBoxAddressAttributeValue(recipient: $recipient, deliveryBoxId: $deliveryBoxId, userId: $userId, zipCode: $zipCode, city: $city, country: $country, phoneNumber: $phoneNumber, state: $state)';
-  }
-
-  @override
   List<Object?> get props => [recipient, deliveryBoxId, userId, zipCode, city, country, phoneNumber, state];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/display_name.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/display_name.dart
@@ -18,8 +18,5 @@ class DisplayNameAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'DisplayNameAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/e_mail_address.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/e_mail_address.dart
@@ -18,8 +18,5 @@ class EMailAddressAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'EMailAddressAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/fax_number.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/fax_number.dart
@@ -18,8 +18,5 @@ class FaxNumberAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'FaxNumberAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/given_name.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/given_name.dart
@@ -18,8 +18,5 @@ class GivenNameAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'GivenNameAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/honorific_prefix.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/honorific_prefix.dart
@@ -18,8 +18,5 @@ class HonorificPrefixAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'HonorificPrefixAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/honorific_suffix.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/honorific_suffix.dart
@@ -18,8 +18,5 @@ class HonorificSuffixAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'HonorificSuffixAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/house_number.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/house_number.dart
@@ -18,8 +18,5 @@ class HouseNumberAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'HouseNumberAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/identity_file_reference.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/identity_file_reference.dart
@@ -18,8 +18,5 @@ class IdentityFileReferenceAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'IdentityFileReferenceAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/job_title.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/job_title.dart
@@ -18,8 +18,5 @@ class JobTitleAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'JobTitleAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/middle_name.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/middle_name.dart
@@ -18,8 +18,5 @@ class MiddleNameAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'MiddleNameAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/nationality.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/nationality.dart
@@ -18,8 +18,5 @@ class NationalityAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'NationalityAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/person_name.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/person_name.dart
@@ -34,10 +34,5 @@ class PersonNameAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() {
-    return 'PersonNameAttributeValue(givenName: $givenName, middleName: $middleName, surname: $surname, honorificSuffix: $honorificSuffix, honorificPrefix: $honorificPrefix)';
-  }
-
-  @override
   List<Object?> get props => [givenName, middleName, surname, honorificSuffix, honorificPrefix];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/phone_number.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/phone_number.dart
@@ -18,8 +18,5 @@ class PhoneNumberAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'PhoneNumberAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/post_office_box_address.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/post_office_box_address.dart
@@ -38,10 +38,5 @@ class PostOfficeBoxAddressAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() {
-    return 'PostOfficeBoxAddressAttributeValue(recipient: $recipient, boxId: $boxId, zipCode: $zipCode, city: $city, country: $country, state: $state)';
-  }
-
-  @override
   List<Object?> get props => [recipient, boxId, zipCode, city, country, state];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/pseudonym.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/pseudonym.dart
@@ -18,8 +18,5 @@ class PseudonymAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'PseudonymAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/sex.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/sex.dart
@@ -18,8 +18,5 @@ class SexAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'SexAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/state.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/state.dart
@@ -18,8 +18,5 @@ class StateAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'StateAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/street.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/street.dart
@@ -18,8 +18,5 @@ class StreetAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'StreetAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/street_address.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/street_address.dart
@@ -42,10 +42,5 @@ class StreetAddressAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() {
-    return 'StreetAddressAttributeValue(recipient: $recipient, street: $street, houseNumber: $houseNumber, zipCode: $zipCode, city: $city, country: $country, state: $state)';
-  }
-
-  @override
   List<Object?> get props => [recipient, street, zipCode, city, country, state];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/surname.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/surname.dart
@@ -18,8 +18,5 @@ class SurnameAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'SurnameAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/website.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/website.dart
@@ -18,8 +18,5 @@ class WebsiteAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'WebsiteAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/identity/zip_code.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/identity/zip_code.dart
@@ -18,8 +18,5 @@ class ZipCodeAttributeValue extends IdentityAttributeValue {
       };
 
   @override
-  String toString() => 'ZipCodeAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/relationship/consent.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/relationship/consent.dart
@@ -27,8 +27,5 @@ class ConsentAttributeValue extends RelationshipAttributeValue {
       };
 
   @override
-  String toString() => 'ConsentAttributeValue(consent: $consent, valueHintsOverride: $valueHintsOverride, link: $link)';
-
-  @override
   List<Object?> get props => [consent, valueHintsOverride, link];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/relationship/proprietary_attribute_value.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/relationship/proprietary_attribute_value.dart
@@ -22,8 +22,5 @@ abstract class ProprietaryAttributeValue extends RelationshipAttributeValue {
       };
 
   @override
-  String toString() => 'ProprietaryAttributeValueAttributeValue(title: $title, description: $description, valueHintsOverride: $valueHintsOverride)';
-
-  @override
   List<Object?> get props => [title, description, valueHintsOverride];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/relationship/proprietary_boolean.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/relationship/proprietary_boolean.dart
@@ -25,8 +25,5 @@ class ProprietaryBooleanAttributeValue extends ProprietaryAttributeValue {
       };
 
   @override
-  String toString() => 'ProprietaryBooleanAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [super.props, value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/relationship/proprietary_country.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/relationship/proprietary_country.dart
@@ -25,8 +25,5 @@ class ProprietaryCountryAttributeValue extends ProprietaryAttributeValue {
       };
 
   @override
-  String toString() => 'ProprietaryCountryAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [super.props, value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/relationship/proprietary_e_mail_address.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/relationship/proprietary_e_mail_address.dart
@@ -25,8 +25,5 @@ class ProprietaryEMailAddressAttributeValue extends ProprietaryAttributeValue {
       };
 
   @override
-  String toString() => 'ProprietaryEMailAddressAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [super.props, value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/relationship/proprietary_file_reference.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/relationship/proprietary_file_reference.dart
@@ -25,8 +25,5 @@ class ProprietaryFileReferenceAttributeValue extends ProprietaryAttributeValue {
       };
 
   @override
-  String toString() => 'ProprietaryFileReferenceAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [super.props, value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/relationship/proprietary_float.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/relationship/proprietary_float.dart
@@ -25,8 +25,5 @@ class ProprietaryFloatAttributeValue extends ProprietaryAttributeValue {
       };
 
   @override
-  String toString() => 'ProprietaryFloatAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [super.props, value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/relationship/proprietary_hex_color.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/relationship/proprietary_hex_color.dart
@@ -25,8 +25,5 @@ class ProprietaryHEXColorAttributeValue extends ProprietaryAttributeValue {
       };
 
   @override
-  String toString() => 'ProprietaryHEXColorAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [super.props, value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/relationship/proprietary_integer.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/relationship/proprietary_integer.dart
@@ -25,8 +25,5 @@ class ProprietaryIntegerAttributeValue extends ProprietaryAttributeValue {
       };
 
   @override
-  String toString() => 'ProprietaryIntegerAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [super.props, value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/relationship/proprietary_json.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/relationship/proprietary_json.dart
@@ -27,8 +27,5 @@ class ProprietaryJSONAttributeValue extends RelationshipAttributeValue {
       };
 
   @override
-  String toString() => 'ProprietaryJSONAttributeValue(title: $title, description: $description, value: $value)';
-
-  @override
   List<Object?> get props => [title, description, value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/relationship/proprietary_language.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/relationship/proprietary_language.dart
@@ -25,8 +25,5 @@ class ProprietaryLanguageAttributeValue extends ProprietaryAttributeValue {
       };
 
   @override
-  String toString() => 'ProprietaryLanguageAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [super.props, value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/relationship/proprietary_phone_number.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/relationship/proprietary_phone_number.dart
@@ -25,8 +25,5 @@ class ProprietaryPhoneNumberAttributeValue extends ProprietaryAttributeValue {
       };
 
   @override
-  String toString() => 'ProprietaryPhoneNumberAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [super.props, value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/relationship/proprietary_string.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/relationship/proprietary_string.dart
@@ -25,8 +25,5 @@ class ProprietaryStringAttributeValue extends ProprietaryAttributeValue {
       };
 
   @override
-  String toString() => 'ProprietaryStringAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [super.props, value];
 }

--- a/packages/enmeshed_types/lib/src/contents/attribute_values/relationship/proprietary_url.dart
+++ b/packages/enmeshed_types/lib/src/contents/attribute_values/relationship/proprietary_url.dart
@@ -25,8 +25,5 @@ class ProprietaryURLAttributeValue extends ProprietaryAttributeValue {
       };
 
   @override
-  String toString() => 'ProprietaryURLAttributeValue(value: $value)';
-
-  @override
   List<Object?> get props => [super.props, value];
 }

--- a/packages/enmeshed_types/lib/src/contents/identity_attribute.dart
+++ b/packages/enmeshed_types/lib/src/contents/identity_attribute.dart
@@ -13,11 +13,6 @@ class IdentityAttribute extends AbstractAttribute {
     this.tags,
   });
 
-  @override
-  String toString() {
-    return 'IdentityAttribute(owner: $owner, validFrom: $validFrom, validTo: $validTo, value: $value, tags: $tags)';
-  }
-
   factory IdentityAttribute.fromJson(Map json) => IdentityAttribute(
         owner: json['owner'],
         validFrom: json['validFrom'],

--- a/packages/enmeshed_types/lib/src/contents/relationship_attribute.dart
+++ b/packages/enmeshed_types/lib/src/contents/relationship_attribute.dart
@@ -19,11 +19,6 @@ class RelationshipAttribute extends AbstractAttribute {
     required this.confidentiality,
   });
 
-  @override
-  String toString() {
-    return 'RelationshipAttribute(owner: $owner, validFrom: $validFrom, validTo: $validTo, value: $value, key: $key, isTechnical: $isTechnical, confidentiality: $confidentiality)';
-  }
-
   factory RelationshipAttribute.fromJson(Map json) => RelationshipAttribute(
         owner: json['owner'],
         validFrom: json['validFrom'],

--- a/packages/enmeshed_types/lib/src/contents/request.dart
+++ b/packages/enmeshed_types/lib/src/contents/request.dart
@@ -43,10 +43,5 @@ class Request extends Equatable {
   }
 
   @override
-  String toString() {
-    return 'Request(id: $id, expiresAt: $expiresAt, items: $items, title: $title, description: $description, metadata: $metadata)';
-  }
-
-  @override
   List<Object?> get props => [id, expiresAt, items, title, description, metadata];
 }

--- a/packages/enmeshed_types/lib/src/contents/request_item/consent_request_item.dart
+++ b/packages/enmeshed_types/lib/src/contents/request_item/consent_request_item.dart
@@ -35,8 +35,5 @@ class ConsentRequestItem extends RequestItemDerivation {
       };
 
   @override
-  String toString() => 'ConsentRequestItem(consent: $consent, link: $link)';
-
-  @override
   List<Object?> get props => [super.props, consent, link];
 }

--- a/packages/enmeshed_types/lib/src/contents/request_item/create_attribute_request_item.dart
+++ b/packages/enmeshed_types/lib/src/contents/request_item/create_attribute_request_item.dart
@@ -31,8 +31,5 @@ class CreateAttributeRequestItem extends RequestItemDerivation {
       };
 
   @override
-  String toString() => 'CreateAttributeRequestItem(attribute: $attribute)';
-
-  @override
   List<Object?> get props => [super.props, attribute];
 }

--- a/packages/enmeshed_types/lib/src/contents/request_item/propose_attribute_request_item.dart
+++ b/packages/enmeshed_types/lib/src/contents/request_item/propose_attribute_request_item.dart
@@ -35,8 +35,5 @@ class ProposeAttributeRequestItem extends RequestItemDerivation {
       };
 
   @override
-  String toString() => 'ProposeAttributeRequestItem(query: $query, attribute: $attribute)';
-
-  @override
   List<Object?> get props => [super.props, query, attribute];
 }

--- a/packages/enmeshed_types/lib/src/contents/request_item/read_attribute_request_item.dart
+++ b/packages/enmeshed_types/lib/src/contents/request_item/read_attribute_request_item.dart
@@ -31,8 +31,5 @@ class ReadAttributeRequestItem extends RequestItemDerivation {
       };
 
   @override
-  String toString() => 'ReadAttributeRequestItem(query: $query)';
-
-  @override
   List<Object?> get props => [super.props, query];
 }

--- a/packages/enmeshed_types/lib/src/contents/request_item/register_attribute_listener_request_item.dart
+++ b/packages/enmeshed_types/lib/src/contents/request_item/register_attribute_listener_request_item.dart
@@ -31,8 +31,5 @@ class RegisterAttributeListenerRequestItem extends RequestItemDerivation {
       };
 
   @override
-  String toString() => 'RegisterAttributeListenerRequestItem(query: $query)';
-
-  @override
   List<Object?> get props => [super.props, query];
 }

--- a/packages/enmeshed_types/lib/src/contents/request_item/request_item.dart
+++ b/packages/enmeshed_types/lib/src/contents/request_item/request_item.dart
@@ -45,11 +45,6 @@ abstract class RequestItem extends Equatable {
         'mustBeAccepted': mustBeAccepted,
       };
 
-  @override
-  String toString() {
-    return 'RequestItem(title: $title, description: $description, metadata: $metadata, mustBeAccepted: $mustBeAccepted)';
-  }
-
   @mustCallSuper
   @override
   List<Object?> get props => [title, description, metadata, mustBeAccepted];

--- a/packages/enmeshed_types/lib/src/contents/request_item/request_item_derivation.dart
+++ b/packages/enmeshed_types/lib/src/contents/request_item/request_item_derivation.dart
@@ -34,8 +34,5 @@ abstract class RequestItemDerivation extends RequestItem {
       };
 
   @override
-  String toString() => 'RequestItemDerivation(requireManualDecision: $requireManualDecision)';
-
-  @override
   List<Object?> get props => [super.props, requireManualDecision];
 }

--- a/packages/enmeshed_types/lib/src/contents/request_item/request_item_group.dart
+++ b/packages/enmeshed_types/lib/src/contents/request_item/request_item_group.dart
@@ -29,8 +29,5 @@ class RequestItemGroup extends RequestItem {
       };
 
   @override
-  String toString() => 'RequestItemGroup(items: $items)';
-
-  @override
   List<Object?> get props => [super.props, items];
 }

--- a/packages/enmeshed_types/lib/src/contents/request_item/share_attribute_request_item.dart
+++ b/packages/enmeshed_types/lib/src/contents/request_item/share_attribute_request_item.dart
@@ -35,8 +35,5 @@ class ShareAttributeRequestItem extends RequestItemDerivation {
       };
 
   @override
-  String toString() => 'ShareAttributeRequestItem(attribute: $attribute, sourceAttributeId: $sourceAttributeId)';
-
-  @override
   List<Object?> get props => [super.props, attribute, sourceAttributeId];
 }

--- a/packages/enmeshed_types/lib/src/contents/response.dart
+++ b/packages/enmeshed_types/lib/src/contents/response.dart
@@ -31,8 +31,5 @@ class Response extends Equatable {
       };
 
   @override
-  String toString() => 'ResponseJSON(result: $result, requestId: $requestId, items: $items)';
-
-  @override
   List<Object?> get props => [result, requestId, items];
 }

--- a/packages/enmeshed_types/lib/src/contents/response_item/create_attribute_accept_response_item.dart
+++ b/packages/enmeshed_types/lib/src/contents/response_item/create_attribute_accept_response_item.dart
@@ -21,8 +21,5 @@ class CreateAttributeAcceptResponseItem extends AcceptResponseItem {
       };
 
   @override
-  String toString() => 'CreateAttributeAcceptResponseItem(attributeId: $attributeId)';
-
-  @override
   List<Object?> get props => [super.props, attributeId];
 }

--- a/packages/enmeshed_types/lib/src/contents/response_item/error_response_item.dart
+++ b/packages/enmeshed_types/lib/src/contents/response_item/error_response_item.dart
@@ -25,8 +25,5 @@ class ErrorResponseItem extends ResponseItemDerivation {
       };
 
   @override
-  String toString() => 'ErrorResponseItem(code: $code, message: $message)';
-
-  @override
   List<Object?> get props => [super.props, code, message];
 }

--- a/packages/enmeshed_types/lib/src/contents/response_item/free_text_accept_response_item.dart
+++ b/packages/enmeshed_types/lib/src/contents/response_item/free_text_accept_response_item.dart
@@ -21,8 +21,5 @@ class FreeTextAcceptResponseItem extends AcceptResponseItem {
       };
 
   @override
-  String toString() => 'FreeTextAcceptResponseItem(freeText: $freeText)';
-
-  @override
   List<Object?> get props => [super.props, freeText];
 }

--- a/packages/enmeshed_types/lib/src/contents/response_item/propose_attribute_accept_response_item.dart
+++ b/packages/enmeshed_types/lib/src/contents/response_item/propose_attribute_accept_response_item.dart
@@ -25,8 +25,5 @@ class ProposeAttributeAcceptResponseItem extends AcceptResponseItem {
       };
 
   @override
-  String toString() => 'ProposeAttributeAcceptResponseItem(attributeId: $attributeId, attribute: $attribute)';
-
-  @override
   List<Object?> get props => [super.props, attributeId, attribute];
 }

--- a/packages/enmeshed_types/lib/src/contents/response_item/read_attribute_accept_response_item.dart
+++ b/packages/enmeshed_types/lib/src/contents/response_item/read_attribute_accept_response_item.dart
@@ -25,8 +25,5 @@ class ReadAttributeAcceptResponseItem extends AcceptResponseItem {
       };
 
   @override
-  String toString() => 'ReadAttributeAcceptResponseItem(attributeId: $attributeId, attribute: $attribute)';
-
-  @override
   List<Object?> get props => [super.props, attributeId, attribute];
 }

--- a/packages/enmeshed_types/lib/src/contents/response_item/register_attribute_listener_accept_response_item.dart
+++ b/packages/enmeshed_types/lib/src/contents/response_item/register_attribute_listener_accept_response_item.dart
@@ -21,8 +21,5 @@ class RegisterAttributeListenerAcceptResponseItem extends AcceptResponseItem {
       };
 
   @override
-  String toString() => 'RegisterAttributeListenerAcceptResponseItem(listenerId: $listenerId)';
-
-  @override
   List<Object?> get props => [super.props, listenerId];
 }

--- a/packages/enmeshed_types/lib/src/contents/response_item/reject_response_item.dart
+++ b/packages/enmeshed_types/lib/src/contents/response_item/reject_response_item.dart
@@ -25,8 +25,5 @@ class RejectResponseItem extends ResponseItemDerivation {
       };
 
   @override
-  String toString() => 'RejectResponseItem(code: $code, message: $message)';
-
-  @override
   List<Object?> get props => [super.props, code, message];
 }

--- a/packages/enmeshed_types/lib/src/contents/response_item/response_item_group.dart
+++ b/packages/enmeshed_types/lib/src/contents/response_item/response_item_group.dart
@@ -20,8 +20,5 @@ class ResponseItemGroup extends ResponseItem {
       };
 
   @override
-  String toString() => 'ResponseItemGroup(items: $items)';
-
-  @override
   List<Object?> get props => [items];
 }

--- a/packages/enmeshed_types/lib/src/contents/response_item/share_attribute_accept_response_item.dart
+++ b/packages/enmeshed_types/lib/src/contents/response_item/share_attribute_accept_response_item.dart
@@ -21,8 +21,5 @@ class ShareAttributeAcceptResponseItem extends AcceptResponseItem {
       };
 
   @override
-  String toString() => 'ShareAttributeAcceptResponseItem(attributeId: $attributeId)';
-
-  @override
   List<Object?> get props => [super.props, attributeId];
 }

--- a/packages/enmeshed_types/lib/src/contents/value_hints.dart
+++ b/packages/enmeshed_types/lib/src/contents/value_hints.dart
@@ -33,11 +33,6 @@ class ValueHints extends Equatable {
   Map<String, dynamic> toJson() => {'@type': 'ValueHints', ..._$ValueHintsToJson(this)};
 
   @override
-  String toString() {
-    return 'ValueHints(editHelp: $editHelp, min: $min, max: $max, pattern: $pattern, values: $values, defaultValue: $defaultValue, propertyHints: $propertyHints)';
-  }
-
-  @override
   List<Object?> get props => [editHelp, min, max, pattern, values, defaultValue, propertyHints];
 }
 

--- a/packages/enmeshed_types/lib/src/contents/value_hints_value.dart
+++ b/packages/enmeshed_types/lib/src/contents/value_hints_value.dart
@@ -19,8 +19,5 @@ class ValueHintsValue extends Equatable {
   Map<String, dynamic> toJson() => {'@type': 'ValueHintsValue', ..._$ValueHintsValueToJson(this)};
 
   @override
-  String toString() => 'ValueHintsValue(key: $key, displayName: $displayName)';
-
-  @override
   List<Object?> get props => [key, displayName];
 }

--- a/packages/enmeshed_types/lib/src/dtos/file.dart
+++ b/packages/enmeshed_types/lib/src/dtos/file.dart
@@ -64,11 +64,6 @@ class FileDTO extends Equatable {
       };
 
   @override
-  String toString() {
-    return 'FileDTO { id: $id, filename: $filename, filesize: $filesize, createdAt: $createdAt, createdBy: $createdBy, createdByDevice: $createdByDevice, expiresAt: $expiresAt, mimetype: $mimetype, isOwn: $isOwn, title: $title, secretKey: $secretKey, description: $description, truncatedReference: $truncatedReference }';
-  }
-
-  @override
   List<Object?> get props =>
       [id, filename, filesize, createdAt, createdBy, createdByDevice, expiresAt, mimetype, isOwn, title, secretKey, description, truncatedReference];
 }

--- a/packages/enmeshed_types/lib/src/dtos/identity.dart
+++ b/packages/enmeshed_types/lib/src/dtos/identity.dart
@@ -11,11 +11,6 @@ class IdentityDTO extends Equatable {
     required this.realm,
   });
 
-  @override
-  String toString() {
-    return 'Identity { address: $address, publicKey: $publicKey, realm: $realm }';
-  }
-
   factory IdentityDTO.fromJson(Map json) {
     return IdentityDTO(
       address: json['address'],

--- a/packages/enmeshed_types/lib/src/dtos/local_account.dart
+++ b/packages/enmeshed_types/lib/src/dtos/local_account.dart
@@ -19,11 +19,6 @@ class LocalAccountDTO extends Equatable {
     this.lastAccessedAt,
   });
 
-  @override
-  String toString() {
-    return 'LocalAccount { id: $id, address: $address, name: $name, realm: $realm, directory: $directory, order: $order }';
-  }
-
   factory LocalAccountDTO.fromJson(Map json) {
     return LocalAccountDTO(
       id: json['id'],

--- a/packages/enmeshed_types/lib/src/dtos/local_attribute.dart
+++ b/packages/enmeshed_types/lib/src/dtos/local_attribute.dart
@@ -55,10 +55,5 @@ class LocalAttributeDTO extends Equatable {
       };
 
   @override
-  String toString() {
-    return 'LocalAttributeDTO(id: $id, parentId: $parentId, createdAt: $createdAt, content: $content, succeeds: $succeeds, succeededBy: $succeededBy, shareInfo: $shareInfo)';
-  }
-
-  @override
   List<Object?> get props => [id, parentId, createdAt, content, succeeds, succeededBy, shareInfo];
 }

--- a/packages/enmeshed_types/lib/src/dtos/local_attribute_listener.dart
+++ b/packages/enmeshed_types/lib/src/dtos/local_attribute_listener.dart
@@ -28,8 +28,5 @@ class LocalAttributeListenerDTO extends Equatable {
       };
 
   @override
-  String toString() => 'LocalAttributeListenerDTO(id: $id, query: $query, peer: $peer)';
-
-  @override
   List<Object?> get props => [id, query, peer];
 }

--- a/packages/enmeshed_types/lib/src/dtos/local_request.dart
+++ b/packages/enmeshed_types/lib/src/dtos/local_request.dart
@@ -51,10 +51,5 @@ class LocalRequestDTO extends Equatable {
       };
 
   @override
-  String toString() {
-    return 'LocalRequestDTO(id: $id, isOwn: $isOwn, peer: $peer, createdAt: $createdAt, status: $status, content: $content, source: $source, response: $response)';
-  }
-
-  @override
   List<Object?> get props => [id, isOwn, peer, createdAt, status, content, source, response];
 }

--- a/packages/enmeshed_types/lib/src/dtos/local_request_source.dart
+++ b/packages/enmeshed_types/lib/src/dtos/local_request_source.dart
@@ -26,8 +26,5 @@ class LocalRequestSourceDTO extends Equatable {
       };
 
   @override
-  String toString() => 'LocalRequestSourceDTO(type: $type, reference: $reference)';
-
-  @override
   List<Object?> get props => [type, reference];
 }

--- a/packages/enmeshed_types/lib/src/dtos/local_response.dart
+++ b/packages/enmeshed_types/lib/src/dtos/local_response.dart
@@ -31,8 +31,5 @@ class LocalResponseDTO extends Equatable {
       };
 
   @override
-  String toString() => 'LocalResponseDTO(createdAt: $createdAt, content: $content, source: $source)';
-
-  @override
   List<Object?> get props => [createdAt, content, source];
 }

--- a/packages/enmeshed_types/lib/src/dtos/local_response_source.dart
+++ b/packages/enmeshed_types/lib/src/dtos/local_response_source.dart
@@ -24,8 +24,5 @@ class LocalResponseSourceDTO extends Equatable {
       };
 
   @override
-  String toString() => 'LocalResponseSourceDTO(type: $type, reference: $reference)';
-
-  @override
   List<Object?> get props => [type, reference];
 }

--- a/packages/enmeshed_types/lib/src/dtos/recipient.dart
+++ b/packages/enmeshed_types/lib/src/dtos/recipient.dart
@@ -28,10 +28,5 @@ class RecipientDTO extends Equatable {
       };
 
   @override
-  String toString() {
-    return 'RecipientDTO { address: $address, receivedAt: $receivedAt, receivedByDevice: $receivedByDevice, relationshipId: $relationshipId }';
-  }
-
-  @override
   List<Object?> get props => [address, receivedAt, receivedByDevice, relationshipId];
 }

--- a/packages/enmeshed_types/lib/src/dtos/relationship.dart
+++ b/packages/enmeshed_types/lib/src/dtos/relationship.dart
@@ -42,10 +42,5 @@ class RelationshipDTO extends Equatable {
       };
 
   @override
-  String toString() {
-    return 'RelationshipDTO(id: $id, template: $template, status: $status, peer: $peer, peerIdentity: $peerIdentity, changes: $changes)';
-  }
-
-  @override
   List<Object?> get props => [id, template, status, peer, peerIdentity, changes];
 }

--- a/packages/enmeshed_types/lib/src/dtos/relationship_change.dart
+++ b/packages/enmeshed_types/lib/src/dtos/relationship_change.dart
@@ -38,10 +38,5 @@ class RelationshipChangeDTO extends Equatable {
       };
 
   @override
-  String toString() {
-    return 'RelationshipChange { id: $id, request: $request, status: $status, type: $type, response: $response }';
-  }
-
-  @override
   List<Object?> get props => [id, request, status, type, response];
 }

--- a/packages/enmeshed_types/lib/src/dtos/relationship_change_request.dart
+++ b/packages/enmeshed_types/lib/src/dtos/relationship_change_request.dart
@@ -30,10 +30,5 @@ class RelationshipChangeRequestDTO extends Equatable {
       };
 
   @override
-  String toString() {
-    return 'RelationshipChangeRequestDTO { createdBy: $createdBy, createdByDevice: $createdByDevice, createdAt: $createdAt, content: $content }';
-  }
-
-  @override
   List<Object?> get props => [createdBy, createdByDevice, createdAt, content];
 }

--- a/packages/enmeshed_types/lib/src/dtos/relationship_change_response.dart
+++ b/packages/enmeshed_types/lib/src/dtos/relationship_change_response.dart
@@ -32,10 +32,5 @@ class RelationshipChangeResponseDTO extends Equatable {
       };
 
   @override
-  String toString() {
-    return 'RelationshipChangeResponseDTO { createdBy: $createdBy, createdByDevice: $createdByDevice, createdAt: $createdAt, content: $content }';
-  }
-
-  @override
   List<Object?> get props => [createdBy, createdByDevice, createdAt, content];
 }

--- a/packages/enmeshed_types/lib/src/dtos/relationship_template.dart
+++ b/packages/enmeshed_types/lib/src/dtos/relationship_template.dart
@@ -54,10 +54,6 @@ class RelationshipTemplateDTO extends Equatable {
       };
 
   @override
-  String toString() =>
-      'RelationshipTemplateDTO(id: $id, isOwn: $isOwn, createdBy: $createdBy, createdByDevice: $createdByDevice, createdAt: $createdAt, content: $content, expiresAt: $expiresAt, maxNumberOfAllocations: $maxNumberOfAllocations, secretKey: $secretKey, truncatedReference: $truncatedReference)';
-
-  @override
   List<Object?> get props => [
         id,
         isOwn,

--- a/packages/enmeshed_types/lib/src/dtos/request_validation_result.dart
+++ b/packages/enmeshed_types/lib/src/dtos/request_validation_result.dart
@@ -13,11 +13,6 @@ class RequestValidationResultDTO extends Equatable {
     required this.items,
   });
 
-  @override
-  String toString() {
-    return 'RequestValidationResult(isSuccess: $isSuccess, code: $code, message: $message, items: $items)';
-  }
-
   factory RequestValidationResultDTO.fromJson(Map json) => RequestValidationResultDTO(
         isSuccess: json['isSuccess'],
         code: json['code'],

--- a/packages/enmeshed_types/lib/src/dtos/token.dart
+++ b/packages/enmeshed_types/lib/src/dtos/token.dart
@@ -25,11 +25,6 @@ class TokenDTO extends Equatable {
     required this.isEphemeral,
   });
 
-  @override
-  String toString() {
-    return 'TokenDTO(id: $id, createdBy: $createdBy, createdByDevice: $createdByDevice, content: $content, createdAt: $createdAt, expiresAt: $expiresAt, secretKey: $secretKey, truncatedReference: $truncatedReference, isEphemeral: $isEphemeral)';
-  }
-
   factory TokenDTO.fromJson(Map json) {
     return TokenDTO(
       id: json['id'],

--- a/packages/enmeshed_types/lib/src/responses/download_file.dart
+++ b/packages/enmeshed_types/lib/src/responses/download_file.dart
@@ -28,8 +28,5 @@ class DownloadFileResponse extends Equatable {
   }
 
   @override
-  String toString() => 'DownloadFileResponse(content: $content, filename: $filename, mimeType: $mimeType)';
-
-  @override
   List<Object?> get props => [content, filename, mimeType];
 }

--- a/packages/enmeshed_types/lib/src/responses/get_identity_info.dart
+++ b/packages/enmeshed_types/lib/src/responses/get_identity_info.dart
@@ -24,8 +24,5 @@ class GetIdentityInfoResponse extends Equatable {
   }
 
   @override
-  String toString() => 'GetIdentityInfoResponse(address: $address, publicKey: $publicKey)';
-
-  @override
   List<Object?> get props => [address, publicKey];
 }

--- a/packages/enmeshed_types/lib/src/responses/load_item_from_truncated_reference.dart
+++ b/packages/enmeshed_types/lib/src/responses/load_item_from_truncated_reference.dart
@@ -48,8 +48,5 @@ class LoadItemFromTruncatedReferenceResponse extends Equatable {
   Map<String, dynamic> toJson() => {'type': type.name, 'value': _value};
 
   @override
-  String toString() => 'LoadItemFromTruncatedReferenceResponse(type: $type, value: $_value)';
-
-  @override
   List<Object?> get props => [type, _value];
 }

--- a/packages/enmeshed_types/lib/src/responses/sync_everything.dart
+++ b/packages/enmeshed_types/lib/src/responses/sync_everything.dart
@@ -26,8 +26,5 @@ class SyncEverythingResponse extends Equatable {
   }
 
   @override
-  String toString() => 'SyncEverythingResponse(relationships: $relationships, messages: $messages)';
-
-  @override
   List<Object?> get props => [relationships, messages];
 }

--- a/packages/enmeshed_types/lib/src/responses/sync_info.dart
+++ b/packages/enmeshed_types/lib/src/responses/sync_info.dart
@@ -22,8 +22,5 @@ class SyncInfoResponse extends Equatable {
       };
 
   @override
-  String toString() => 'SyncInfoResponse(lastDatawalletSync: $lastDatawalletSync, lastSyncRun: $lastSyncRun)';
-
-  @override
   List<Object?> get props => [lastDatawalletSync, lastSyncRun];
 }

--- a/packages/enmeshed_types/lib/src/responses/sync_info_entry.dart
+++ b/packages/enmeshed_types/lib/src/responses/sync_info_entry.dart
@@ -12,8 +12,5 @@ class SyncInfoEntry extends Equatable {
   Map<String, dynamic> toJson() => {'completedAt': completedAt};
 
   @override
-  String toString() => 'SyncInfoEntry(completedAt: $completedAt)';
-
-  @override
   List<Object?> get props => [completedAt];
 }


### PR DESCRIPTION
We used them for debugging purposes in the beginning, but we don't do this anymore.