### PR TITLE
Fix/show contents when item is already shared or succeeded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ config.*.json
 
 apps/connector_ui/android/local.properties
 .DS_Store
+
+.env
+.env.*

--- a/packages/renderers/lib/src/request/request_item_renderer/response/attribute_already_shared_accept_response_item_renderer.dart
+++ b/packages/renderers/lib/src/request/request_item_renderer/response/attribute_already_shared_accept_response_item_renderer.dart
@@ -1,0 +1,36 @@
+import 'package:enmeshed_types/enmeshed_types.dart';
+import 'package:flutter/material.dart';
+
+import '/src/attribute/identity_attribute_value_renderer.dart';
+import '/src/attribute/relationship_attribute_value_renderer.dart';
+
+class AttributeAlreadySharedAcceptResponseItemRenderer extends StatelessWidget {
+  final AttributeAlreadySharedAcceptResponseItemDVO item;
+  final Future<FileDVO> Function(String) expandFileReference;
+  final void Function(FileDVO) openFileDetails;
+
+  const AttributeAlreadySharedAcceptResponseItemRenderer({
+    super.key,
+    required this.item,
+    required this.expandFileReference,
+    required this.openFileDetails,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (item.attribute.value) {
+      final IdentityAttributeValue value => IdentityAttributeValueRenderer(
+          value: value,
+          valueHints: item.attribute.valueHints,
+          expandFileReference: expandFileReference,
+          openFileDetails: openFileDetails,
+        ),
+      final RelationshipAttributeValue value => RelationshipAttributeValueRenderer(
+          value: value,
+          expandFileReference: expandFileReference,
+          openFileDetails: openFileDetails,
+        ),
+      _ => throw Exception('Unknown AttributeValue: ${item.attribute.valueType}'),
+    };
+  }
+}

--- a/packages/renderers/lib/src/request/request_item_renderer/response/attribute_succession_accept_response_item_renderer.dart
+++ b/packages/renderers/lib/src/request/request_item_renderer/response/attribute_succession_accept_response_item_renderer.dart
@@ -1,0 +1,36 @@
+import 'package:enmeshed_types/enmeshed_types.dart';
+import 'package:flutter/material.dart';
+
+import '/src/attribute/identity_attribute_value_renderer.dart';
+import '/src/attribute/relationship_attribute_value_renderer.dart';
+
+class AttributeSuccessionAcceptResponseItemRenderer extends StatelessWidget {
+  final AttributeSuccessionAcceptResponseItemDVO item;
+  final Future<FileDVO> Function(String) expandFileReference;
+  final void Function(FileDVO) openFileDetails;
+
+  const AttributeSuccessionAcceptResponseItemRenderer({
+    super.key,
+    required this.item,
+    required this.expandFileReference,
+    required this.openFileDetails,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (item.successor.value) {
+      final IdentityAttributeValue value => IdentityAttributeValueRenderer(
+          value: value,
+          valueHints: item.successor.valueHints,
+          expandFileReference: expandFileReference,
+          openFileDetails: openFileDetails,
+        ),
+      final RelationshipAttributeValue value => RelationshipAttributeValueRenderer(
+          value: value,
+          expandFileReference: expandFileReference,
+          openFileDetails: openFileDetails,
+        ),
+      _ => throw Exception('Unknown AttributeValue: ${item.successor.valueType}'),
+    };
+  }
+}

--- a/packages/renderers/lib/src/request/request_item_renderer/response/response.dart
+++ b/packages/renderers/lib/src/request/request_item_renderer/response/response.dart
@@ -1,4 +1,6 @@
 export 'accept_response_item_renderer.dart';
+export 'attribute_already_shared_accept_response_item_renderer.dart';
+export 'attribute_succession_accept_response_item_renderer.dart';
 export 'create_attribute_accept_response_item_renderer.dart';
 export 'propose_attribute_accept_response_item_renderer.dart';
 export 'read_attribute_accept_response_item_renderer.dart';

--- a/packages/renderers/lib/src/request/request_item_renderer/response/response_item_renderer.dart
+++ b/packages/renderers/lib/src/request/request_item_renderer/response/response_item_renderer.dart
@@ -33,6 +33,16 @@ class ResponseItemRenderer extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 12),
       child: switch (responseItem) {
+        final AttributeAlreadySharedAcceptResponseItemDVO dvo => AttributeAlreadySharedAcceptResponseItemRenderer(
+            item: dvo,
+            expandFileReference: expandFileReference,
+            openFileDetails: openFileDetails,
+          ),
+        final AttributeSuccessionAcceptResponseItemDVO dvo => AttributeSuccessionAcceptResponseItemRenderer(
+            item: dvo,
+            expandFileReference: expandFileReference,
+            openFileDetails: openFileDetails,
+          ),
         final ReadAttributeAcceptResponseItemDVO dvo => ReadAttributeAcceptResponseItemRenderer(
             item: dvo,
             expandFileReference: expandFileReference,


### PR DESCRIPTION
For now simple copy paste / reuse of the logic from the `ReadAttributeAcceptResponseItemRenderer` rendering the already shared Attribute for the `AttributeAlreadySharedAcceptResponseItemDVO` and the successor for the `AttributeSuccessionAcceptResponseItemDVO`.