### PR TITLE
Android controls overlapping app contents

### DIFF
--- a/apps/enmeshed/lib/account/app_drawer/app_drawer.dart
+++ b/apps/enmeshed/lib/account/app_drawer/app_drawer.dart
@@ -18,7 +18,7 @@ class _AppDrawerState extends State<AppDrawer> {
 
   @override
   Widget build(BuildContext context) {
-    final maxWidth = MediaQuery.of(context).size.width * 0.85;
+    final maxWidth = MediaQuery.sizeOf(context).width * 0.85;
 
     return SafeArea(
       child: Drawer(

--- a/apps/enmeshed/lib/account/mailbox/modals/select_mailbox_filters.dart
+++ b/apps/enmeshed/lib/account/mailbox/modals/select_mailbox_filters.dart
@@ -16,8 +16,8 @@ Future<Set<MailboxFilterOption>?> showSelectMailboxFiltersModal({
     context: context,
     isScrollControlled: true,
     elevation: 0,
-    builder: (context) => FractionallySizedBox(
-      heightFactor: 0.75,
+    builder: (context) => ConstrainedBox(
+      constraints: BoxConstraints(maxHeight: MediaQuery.sizeOf(context).height * 0.75),
       child: _SelectMailboxFiltersModal(contacts: contacts, mailboxFilterController: mailboxFilterController),
     ),
   );
@@ -103,9 +103,9 @@ class _SelectMailboxFiltersModalState extends State<_SelectMailboxFiltersModal> 
         ),
         Gaps.h16,
         ListTile(title: Text(context.l10n.mailbox_filter_byContacts, style: Theme.of(context).textTheme.titleMedium)),
-        Expanded(
+        Flexible(
           child: widget.contacts.isEmpty
-              ? EmptyListIndicator(icon: Icons.contacts, text: context.l10n.contacts_empty, wrapInListView: true)
+              ? EmptyListIndicator(icon: Icons.contacts, text: context.l10n.contacts_empty)
               : ListView.separated(
                   itemCount: widget.contacts.length,
                   separatorBuilder: (BuildContext context, int index) => const Divider(height: 1, indent: 16),

--- a/apps/enmeshed/lib/account/mailbox/modals/select_mailbox_filters.dart
+++ b/apps/enmeshed/lib/account/mailbox/modals/select_mailbox_filters.dart
@@ -50,7 +50,7 @@ class _SelectMailboxFiltersModalState extends State<_SelectMailboxFiltersModal> 
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
       mainAxisSize: MainAxisSize.min,
-      children: <Widget>[
+      children: [
         ListTile(
           contentPadding: const EdgeInsets.only(left: 16, right: 16, top: 8),
           title: Text(
@@ -146,16 +146,16 @@ class _ModalSheetFooter extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       mainAxisAlignment: MainAxisAlignment.end,
-      children: <Widget>[
+      children: [
         Material(
           elevation: 10,
           child: Padding(
-            padding: EdgeInsets.only(bottom: MediaQuery.viewInsetsOf(context).bottom + 16),
+            padding: EdgeInsets.only(bottom: MediaQuery.viewPaddingOf(context).bottom),
             child: Container(
               padding: const EdgeInsets.fromLTRB(0, 4, 0, 4),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.end,
-                children: <Widget>[
+                children: [
                   OutlinedButton(
                     onPressed: resetFilters,
                     child: Text(

--- a/apps/enmeshed/lib/account/mailbox/send_mail_screen/widgets/choose_contact.dart
+++ b/apps/enmeshed/lib/account/mailbox/send_mail_screen/widgets/choose_contact.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:enmeshed_types/enmeshed_types.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -84,7 +82,7 @@ class _ContactsSheet extends StatelessWidget {
           ),
           Flexible(
             child: Padding(
-              padding: EdgeInsets.only(bottom: max(MediaQuery.paddingOf(context).bottom, 16)),
+              padding: EdgeInsets.only(bottom: MediaQuery.viewPaddingOf(context).bottom + 16),
               child: Scrollbar(
                 thumbVisibility: true,
                 child: SingleChildScrollView(

--- a/apps/enmeshed/lib/account/my_data/file/file_detail_screen.dart
+++ b/apps/enmeshed/lib/account/my_data/file/file_detail_screen.dart
@@ -49,7 +49,7 @@ class _FileDetailScreenState extends State<FileDetailScreen> {
       ),
       body: SafeArea(
         child: Padding(
-          padding: EdgeInsets.only(top: 8, left: 24, right: 24, bottom: MediaQuery.viewInsetsOf(context).bottom + 42),
+          padding: const EdgeInsets.only(top: 8, left: 24, right: 24),
           child: _fileDVO == null
               ? const Center(child: CircularProgressIndicator())
               : Column(

--- a/apps/enmeshed/lib/account/my_data/initial_creation/my_data_initial_creation_screen.dart
+++ b/apps/enmeshed/lib/account/my_data/initial_creation/my_data_initial_creation_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:enmeshed_runtime_bridge/enmeshed_runtime_bridge.dart';
 import 'package:enmeshed_types/enmeshed_types.dart';
 import 'package:flutter/material.dart';
@@ -146,19 +148,21 @@ class _MyDataInitialCreationScreenState extends State<MyDataInitialCreationScree
       bottomNavigationBar: Material(
         elevation: 10,
         child: Padding(
-          padding: EdgeInsets.only(bottom: MediaQuery.viewInsetsOf(context).bottom + 16),
+          padding: EdgeInsets.only(
+            bottom: max(MediaQuery.viewPaddingOf(context).bottom, MediaQuery.viewInsetsOf(context).bottom),
+            right: 16,
+          ),
           child: Container(
             padding: const EdgeInsets.fromLTRB(0, 4, 0, 4),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
                 OutlinedButton(onPressed: _isLoading ? null : widget.resetType ?? () => context.pop(), child: Text(context.l10n.cancel)),
-                Gaps.w4,
+                Gaps.w8,
                 FilledButton(
                   onPressed: _saveEnabled && !_isLoading ? _createAttributes : null,
                   child: Text(context.l10n.save),
                 ),
-                Gaps.w16,
               ],
             ),
           ),

--- a/apps/enmeshed/lib/core/modals/create_attribute.dart
+++ b/apps/enmeshed/lib/core/modals/create_attribute.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math';
 
 import 'package:enmeshed_runtime_bridge/enmeshed_runtime_bridge.dart';
 import 'package:enmeshed_types/enmeshed_types.dart';
@@ -131,7 +132,10 @@ Future<void> showCreateAttributeModal({
           valueListenable: createEnabledNotifier,
           builder: (context, enabled, child) {
             return Padding(
-              padding: EdgeInsets.only(right: MediaQuery.viewInsetsOf(context).right + 24, bottom: MediaQuery.viewInsetsOf(context).bottom + 16),
+              padding: EdgeInsets.only(
+                right: 24,
+                bottom: max(MediaQuery.viewInsetsOf(context).bottom, MediaQuery.viewPaddingOf(context).bottom) + 16,
+              ),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: [
@@ -171,12 +175,13 @@ Future<void> showCreateAttributeModal({
                       icon: const Icon(Icons.arrow_back),
                       onPressed: () => pageIndexNotifier.value = 0,
                     ),
-                  Padding(
-                    padding: EdgeInsets.only(top: 24, bottom: MediaQuery.viewInsetsOf(context).bottom + 24),
-                    child: valueType == null
-                        ? Text(context.l10n.error, style: Theme.of(context).textTheme.titleLarge)
-                        : Text(context.l10n.myData_createAttribute_title(translatedAttribute), style: Theme.of(context).textTheme.titleSmall),
-                  ),
+                  if (valueType == null)
+                    Text(context.l10n.error, style: Theme.of(context).textTheme.titleLarge)
+                  else
+                    Text(
+                      context.l10n.myData_createAttribute_title(translatedAttribute),
+                      style: initialValueType == null ? Theme.of(context).textTheme.titleSmall : Theme.of(context).textTheme.titleLarge,
+                    ),
                 ],
               ),
             );
@@ -187,13 +192,13 @@ Future<void> showCreateAttributeModal({
           builder: (context, valueType, child) {
             if (valueType == null) {
               return Padding(
-                padding: EdgeInsets.only(left: 24, right: 24, bottom: MediaQuery.viewInsetsOf(context).bottom + 80),
+                padding: EdgeInsets.only(left: 24, right: 24, bottom: MediaQuery.viewPaddingOf(context).bottom + 80),
                 child: Text(context.l10n.errorDialog_description),
               );
             }
 
             return Padding(
-              padding: EdgeInsets.only(left: 16, right: 16, bottom: MediaQuery.viewInsetsOf(context).bottom + 80),
+              padding: EdgeInsets.only(left: 16, right: 16, bottom: MediaQuery.viewPaddingOf(context).bottom + 80),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
@@ -252,7 +257,7 @@ class _EditableAttributesState extends State<_EditableAttributes> {
   Widget build(BuildContext context) {
     if (_editableAttributes == null) {
       return Padding(
-        padding: EdgeInsets.only(left: 24, right: 24, top: 16, bottom: MediaQuery.viewInsetsOf(context).bottom + 24),
+        padding: EdgeInsets.only(left: 24, right: 24, top: 16, bottom: MediaQuery.viewPaddingOf(context).bottom),
         child: const Center(child: CircularProgressIndicator()),
       );
     }
@@ -281,7 +286,7 @@ class _EditableAttributesState extends State<_EditableAttributes> {
           ),
           separatorBuilder: (context, index) => const Divider(height: 0, indent: 16),
         ),
-        SizedBox(height: MediaQuery.viewInsetsOf(context).bottom + 24),
+        SizedBox(height: MediaQuery.viewPaddingOf(context).bottom),
       ],
     );
   }

--- a/apps/enmeshed/lib/core/modals/create_recovery_kit/enter_password.dart
+++ b/apps/enmeshed/lib/core/modals/create_recovery_kit/enter_password.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 
 import '../../constants.dart';
@@ -32,7 +30,7 @@ class _EnterPasswordState extends State<EnterPassword> {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: EdgeInsets.only(left: 24, right: 24, bottom: max(MediaQuery.paddingOf(context).bottom, 16)),
+      padding: EdgeInsets.only(left: 24, right: 24, bottom: MediaQuery.viewPaddingOf(context).bottom),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -62,12 +60,15 @@ class _EnterPasswordState extends State<EnterPassword> {
                     return null;
                   },
                 ),
-                Gaps.h48,
-                Align(
-                  alignment: Alignment.centerRight,
-                  child: FilledButton(
-                    onPressed: _onSubmit,
-                    child: Text(context.l10n.identityRecovery_startNow),
+                Gaps.h40,
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 8),
+                  child: Align(
+                    alignment: Alignment.centerRight,
+                    child: FilledButton(
+                      onPressed: _onSubmit,
+                      child: Text(context.l10n.identityRecovery_startNow),
+                    ),
                   ),
                 ),
               ],

--- a/apps/enmeshed/lib/core/modals/create_recovery_kit/save_or_print_recovery_kit.dart
+++ b/apps/enmeshed/lib/core/modals/create_recovery_kit/save_or_print_recovery_kit.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:math' as math;
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
@@ -38,7 +37,7 @@ class _SaveOrPrintRecoveryKitState extends State<SaveOrPrintRecoveryKit> {
           ),
         ),
         Padding(
-          padding: EdgeInsets.only(left: 24, right: 24, top: 20, bottom: math.max(MediaQuery.paddingOf(context).bottom, 16) + 16),
+          padding: EdgeInsets.only(left: 24, right: 24, top: 20, bottom: MediaQuery.viewPaddingOf(context).bottom + 16),
           child: Column(
             children: [
               Text(context.l10n.identityRecovery_saveKitDescription),

--- a/apps/enmeshed/lib/core/modals/delete_attribute.dart
+++ b/apps/enmeshed/lib/core/modals/delete_attribute.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:enmeshed_runtime_bridge/enmeshed_runtime_bridge.dart';
 import 'package:enmeshed_types/enmeshed_types.dart';
 import 'package:flutter/material.dart';
@@ -122,7 +120,7 @@ Future<void> showDeleteAttributeModal({
           valueListenable: deleteEnabledNotifier,
           builder: (context, enabled, child) {
             return Padding(
-              padding: EdgeInsets.only(right: 24, bottom: max(MediaQuery.paddingOf(context).bottom, 24)),
+              padding: EdgeInsets.only(right: 24, bottom: MediaQuery.viewPaddingOf(context).bottom),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: [
@@ -159,7 +157,7 @@ class _DeleteConfirmation extends StatelessWidget {
     final isShared = attribute.sharedWith.isNotEmpty;
 
     return Padding(
-      padding: EdgeInsets.only(left: 24, right: 24, bottom: max(MediaQuery.paddingOf(context).bottom, 16) + 72),
+      padding: EdgeInsets.only(left: 24, right: 24, bottom: MediaQuery.viewPaddingOf(context).bottom + 72),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/apps/enmeshed/lib/core/modals/delete_local_data.dart
+++ b/apps/enmeshed/lib/core/modals/delete_local_data.dart
@@ -46,7 +46,7 @@ class _DeleteLocalDataModalState extends State<_DeleteLocalDataModal> {
   @override
   Widget build(BuildContext context) {
     return ConstrainedBox(
-      constraints: BoxConstraints(maxHeight: MediaQuery.of(context).size.height * 0.8),
+      constraints: BoxConstraints(maxHeight: MediaQuery.sizeOf(context).height * 0.8),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/apps/enmeshed/lib/core/modals/enter_password/enter_password.dart
+++ b/apps/enmeshed/lib/core/modals/enter_password/enter_password.dart
@@ -1,4 +1,4 @@
-import 'dart:math' as math;
+import 'dart:math';
 
 import 'package:enmeshed_runtime_bridge/enmeshed_runtime_bridge.dart';
 import 'package:flutter/material.dart';
@@ -19,7 +19,7 @@ class EnterPasswordModal extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: EdgeInsets.only(bottom: math.max(MediaQuery.viewInsetsOf(context).bottom, 24)),
+      padding: EdgeInsets.only(bottom: max(MediaQuery.viewInsetsOf(context).bottom, MediaQuery.viewPaddingOf(context).bottom)),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [

--- a/apps/enmeshed/lib/core/modals/restore_identity.dart
+++ b/apps/enmeshed/lib/core/modals/restore_identity.dart
@@ -32,7 +32,7 @@ class _RestoreIdentity extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: EdgeInsets.only(left: 24, right: 24, top: 16, bottom: MediaQuery.viewInsetsOf(context).bottom + 24),
+      padding: EdgeInsets.only(left: 24, right: 24, top: 16, bottom: MediaQuery.viewPaddingOf(context).bottom),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [

--- a/apps/enmeshed/lib/core/modals/succeed_attribute.dart
+++ b/apps/enmeshed/lib/core/modals/succeed_attribute.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:math';
 
 import 'package:enmeshed_runtime_bridge/enmeshed_runtime_bridge.dart';
 import 'package:enmeshed_types/enmeshed_types.dart';
@@ -177,7 +176,7 @@ Future<void> showSucceedAttributeModal({
           valueListenable: succeedEnabledNotifier,
           builder: (context, enabled, child) {
             return Padding(
-              padding: EdgeInsets.only(right: 24, bottom: max(MediaQuery.paddingOf(context).bottom, 24)),
+              padding: EdgeInsets.only(right: 24, bottom: MediaQuery.viewPaddingOf(context).bottom + 16),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: [
@@ -204,7 +203,7 @@ Future<void> showSucceedAttributeModal({
           valueListenable: errorTextNotifier,
           builder: (context, errorText, child) {
             return Padding(
-              padding: EdgeInsets.only(left: 16, right: 16, bottom: max(MediaQuery.paddingOf(context).bottom, 16) + 72),
+              padding: EdgeInsets.only(left: 24, right: 24, bottom: MediaQuery.viewPaddingOf(context).bottom + 72),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [

--- a/apps/enmeshed/lib/core/widgets/file_chooser.dart
+++ b/apps/enmeshed/lib/core/widgets/file_chooser.dart
@@ -69,8 +69,8 @@ class _FileChooserState extends State<_FileChooser> {
     }
 
     if (_mode == _FileChooserMode.existing) {
-      return FractionallySizedBox(
-        heightFactor: 0.8,
+      return ConstrainedBox(
+        constraints: BoxConstraints(maxHeight: MediaQuery.sizeOf(context).height * 0.8),
         child: Column(
           children: [
             Padding(
@@ -96,43 +96,42 @@ class _FileChooserState extends State<_FileChooser> {
               ),
             ),
             Expanded(
-              child: Padding(
-                padding: EdgeInsets.only(bottom: MediaQuery.of(context).padding.bottom),
-                child: _existingFiles!.isEmpty
-                    ? EmptyListIndicator(icon: Icons.file_copy, text: context.l10n.fileChooser_noFilesFound)
-                    : Scrollbar(
-                        thumbVisibility: true,
-                        child: ListView.separated(
-                          clipBehavior: Clip.antiAlias,
-                          itemCount: _existingFiles!.length,
-                          itemBuilder: (context, index) {
-                            final file = _existingFiles![index];
+              child: _existingFiles!.isEmpty
+                  ? EmptyListIndicator(icon: Icons.file_copy, text: context.l10n.fileChooser_noFilesFound)
+                  : Scrollbar(
+                      thumbVisibility: true,
+                      child: ListView.separated(
+                        shrinkWrap: true,
+                        clipBehavior: Clip.antiAlias,
+                        itemCount: _existingFiles!.length,
+                        padding: EdgeInsets.only(bottom: MediaQuery.paddingOf(context).bottom),
+                        itemBuilder: (context, index) {
+                          final file = _existingFiles![index];
 
-                            return ListTile(
-                              title: Text(file.title),
-                              subtitle: Text(file.filename),
-                              onTap: () {
-                                if (widget.selectedFiles == null) return context.pop(file);
+                          return ListTile(
+                            title: Text(file.title),
+                            subtitle: Text(file.filename),
+                            onTap: () {
+                              if (widget.selectedFiles == null) return context.pop(file);
 
-                                setState(() => widget.selectedFiles!.toggle(file));
-                                widget.onSelectedAttachmentsChanged?.call();
-                              },
-                              leading: FileIcon(filename: file.filename),
-                              trailing: widget.selectedFiles == null
-                                  ? const Icon(Icons.chevron_right)
-                                  : Checkbox(
-                                      value: widget.selectedFiles!.contains(file),
-                                      onChanged: (_) {
-                                        setState(() => widget.selectedFiles!.toggle(file));
-                                        widget.onSelectedAttachmentsChanged?.call();
-                                      },
-                                    ),
-                            );
-                          },
-                          separatorBuilder: (context, index) => const Divider(height: 0, indent: 16),
-                        ),
+                              setState(() => widget.selectedFiles!.toggle(file));
+                              widget.onSelectedAttachmentsChanged?.call();
+                            },
+                            leading: FileIcon(filename: file.filename),
+                            trailing: widget.selectedFiles == null
+                                ? const Icon(Icons.chevron_right)
+                                : Checkbox(
+                                    value: widget.selectedFiles!.contains(file),
+                                    onChanged: (_) {
+                                      setState(() => widget.selectedFiles!.toggle(file));
+                                      widget.onSelectedAttachmentsChanged?.call();
+                                    },
+                                  ),
+                          );
+                        },
+                        separatorBuilder: (context, index) => const Divider(height: 0, indent: 16),
                       ),
-              ),
+                    ),
             ),
           ],
         ),
@@ -166,7 +165,12 @@ class _FileChooserState extends State<_FileChooser> {
     final files = await session.transportServices.files.getFiles();
     final expanded = await session.expander.expandFileDTOs(files.value);
     setState(() {
-      _existingFiles = expanded;
+      _existingFiles = [
+        ...expanded,
+        ...expanded,
+        ...expanded,
+        ...expanded,
+      ];
     });
   }
 }

--- a/apps/enmeshed/lib/core/widgets/file_chooser.dart
+++ b/apps/enmeshed/lib/core/widgets/file_chooser.dart
@@ -165,12 +165,7 @@ class _FileChooserState extends State<_FileChooser> {
     final files = await session.transportServices.files.getFiles();
     final expanded = await session.expander.expandFileDTOs(files.value);
     setState(() {
-      _existingFiles = [
-        ...expanded,
-        ...expanded,
-        ...expanded,
-        ...expanded,
-      ];
+      _existingFiles = expanded;
     });
   }
 }

--- a/apps/enmeshed/lib/core/widgets/file_chooser.dart
+++ b/apps/enmeshed/lib/core/widgets/file_chooser.dart
@@ -101,7 +101,6 @@ class _FileChooserState extends State<_FileChooser> {
                   : Scrollbar(
                       thumbVisibility: true,
                       child: ListView.separated(
-                        shrinkWrap: true,
                         clipBehavior: Clip.antiAlias,
                         itemCount: _existingFiles!.length,
                         padding: EdgeInsets.only(bottom: MediaQuery.paddingOf(context).bottom),

--- a/apps/enmeshed/lib/core/widgets/request_dvo_renderer.dart
+++ b/apps/enmeshed/lib/core/widgets/request_dvo_renderer.dart
@@ -422,7 +422,7 @@ class _AttributeSwitcherState extends State<_AttributeSwitcher> {
               ],
             ),
             child: Padding(
-              padding: EdgeInsets.only(right: 16, bottom: MediaQuery.viewInsetsOf(context).bottom + 24, top: 8),
+              padding: EdgeInsets.only(right: 16, bottom: MediaQuery.viewPaddingOf(context).bottom, top: 8),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: [

--- a/apps/enmeshed/lib/core/widgets/scanner_view/scanner_entry.dart
+++ b/apps/enmeshed/lib/core/widgets/scanner_view/scanner_entry.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 
 import 'package:enmeshed_ui_kit/enmeshed_ui_kit.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
 import 'package:logger/logger.dart';
@@ -80,109 +81,112 @@ class _ScannerEntryState extends State<ScannerEntry> with SingleTickerProviderSt
     final scanWindowY = (screenSize.height - scannerWindowSize) / 2;
     final scanWindow = Rect.fromLTWH(scanWindowX, scanWindowY, scannerWindowSize, scannerWindowSize);
 
-    return Stack(
-      fit: StackFit.expand,
-      children: [
-        MobileScanner(
-          controller: _cameraController,
-          onDetect: onDetect,
-          scanWindow: scanWindow,
-        ),
-        CustomPaint(
-          painter: StaticScannerOverlay(
+    return AnnotatedRegion<SystemUiOverlayStyle>(
+      value: SystemUiOverlayStyle.light,
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          MobileScanner(
+            controller: _cameraController,
+            onDetect: onDetect,
             scanWindow: scanWindow,
-            scanWindowColor: scanWindowColor,
           ),
-        ),
-        CustomPaint(
-          painter: AnimatedScannerOverlay(
-            scanWindow: scanWindow,
-            animationValue: _animation.value,
-            animateDirection: animationDirection,
-            scanWindowColor: scanWindowColor,
+          CustomPaint(
+            painter: StaticScannerOverlay(
+              scanWindow: scanWindow,
+              scanWindowColor: scanWindowColor,
+            ),
           ),
-        ),
-        Positioned.fill(
-          top: -355,
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Icon(Icons.qr_code_scanner, size: 45, color: Theme.of(context).colorScheme.onPrimary),
-              Gaps.w16,
-              SizedBox(
-                width: 200,
-                child: Text(
-                  widget.lineUpQrCodeText,
-                  style: Theme.of(context).textTheme.bodyLarge!.copyWith(color: Theme.of(context).colorScheme.onPrimary),
+          CustomPaint(
+            painter: AnimatedScannerOverlay(
+              scanWindow: scanWindow,
+              animationValue: _animation.value,
+              animateDirection: animationDirection,
+              scanWindowColor: scanWindowColor,
+            ),
+          ),
+          Positioned.fill(
+            top: -355,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(Icons.qr_code_scanner, size: 45, color: Theme.of(context).colorScheme.onPrimary),
+                Gaps.w16,
+                SizedBox(
+                  width: 200,
+                  child: Text(
+                    widget.lineUpQrCodeText,
+                    style: Theme.of(context).textTheme.bodyLarge!.copyWith(color: Theme.of(context).colorScheme.onPrimary),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Positioned(
+            top: 56,
+            left: 8,
+            child: ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                shape: const CircleBorder(),
+                backgroundColor: Theme.of(context).colorScheme.primary,
+              ),
+              child: Icon(context.adaptiveBackIcon, color: Theme.of(context).colorScheme.onPrimary, size: 18),
+              onPressed: () => context.pop(),
+            ),
+          ),
+          Positioned(
+            top: 56,
+            right: 8,
+            child: ValueListenableBuilder(
+              valueListenable: _cameraController,
+              builder: (context, state, child) => IconButton(
+                style: IconButton.styleFrom(backgroundColor: Theme.of(context).colorScheme.primary),
+                onPressed: state.torchState == TorchState.unavailable ? null : _cameraController.toggleTorch,
+                icon: switch (state.torchState) {
+                  TorchState.off || TorchState.unavailable => Icon(Icons.flashlight_off, color: Theme.of(context).colorScheme.onPrimary, size: 18),
+                  TorchState.on => Icon(Icons.flashlight_on, color: context.customColors.decorativeContainer, size: 18),
+                  TorchState.auto => Icon(Icons.flash_auto, color: Theme.of(context).colorScheme.onPrimary, size: 18),
+                },
+              ),
+            ),
+          ),
+          Positioned(
+            bottom: 0,
+            left: 0,
+            right: 0,
+            child: Container(
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.primary,
+                borderRadius: const BorderRadius.only(topLeft: Radius.circular(12), topRight: Radius.circular(12)),
+              ),
+              child: Padding(
+                padding: EdgeInsets.only(top: 24, bottom: math.max(MediaQuery.paddingOf(context).bottom, 24) + 8),
+                child: Column(
+                  children: [
+                    SizedBox(
+                      width: 203,
+                      child: Text(
+                        widget.scanQrOrEnterUrlText,
+                        style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                    Gaps.h16,
+                    OutlinedButton(
+                      onPressed: widget.toggleScannerMode,
+                      style: OutlinedButton.styleFrom(
+                        side: BorderSide(color: Theme.of(context).colorScheme.onPrimary),
+                        foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                      ),
+                      child: Text(widget.enterUrlText),
+                    ),
+                  ],
                 ),
               ),
-            ],
-          ),
-        ),
-        Positioned(
-          top: 56,
-          left: 8,
-          child: ElevatedButton(
-            style: ElevatedButton.styleFrom(
-              shape: const CircleBorder(),
-              backgroundColor: Theme.of(context).colorScheme.primary,
-            ),
-            child: Icon(context.adaptiveBackIcon, color: Theme.of(context).colorScheme.onPrimary, size: 18),
-            onPressed: () => context.pop(),
-          ),
-        ),
-        Positioned(
-          top: 56,
-          right: 8,
-          child: ValueListenableBuilder(
-            valueListenable: _cameraController,
-            builder: (context, state, child) => IconButton(
-              style: IconButton.styleFrom(backgroundColor: Theme.of(context).colorScheme.primary),
-              onPressed: state.torchState == TorchState.unavailable ? null : _cameraController.toggleTorch,
-              icon: switch (state.torchState) {
-                TorchState.off || TorchState.unavailable => Icon(Icons.flashlight_off, color: Theme.of(context).colorScheme.onPrimary, size: 18),
-                TorchState.on => Icon(Icons.flashlight_on, color: context.customColors.decorativeContainer, size: 18),
-                TorchState.auto => Icon(Icons.flash_auto, color: Theme.of(context).colorScheme.onPrimary, size: 18),
-              },
             ),
           ),
-        ),
-        Positioned(
-          bottom: 0,
-          left: 0,
-          right: 0,
-          child: Container(
-            decoration: BoxDecoration(
-              color: Theme.of(context).colorScheme.primary,
-              borderRadius: const BorderRadius.only(topLeft: Radius.circular(12), topRight: Radius.circular(12)),
-            ),
-            child: Padding(
-              padding: EdgeInsets.only(top: 24, bottom: math.max(MediaQuery.paddingOf(context).bottom, 24)),
-              child: Column(
-                children: [
-                  SizedBox(
-                    width: 203,
-                    child: Text(
-                      widget.scanQrOrEnterUrlText,
-                      style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
-                      textAlign: TextAlign.center,
-                    ),
-                  ),
-                  Gaps.h16,
-                  OutlinedButton(
-                    onPressed: widget.toggleScannerMode,
-                    style: OutlinedButton.styleFrom(
-                      side: BorderSide(color: Theme.of(context).colorScheme.onPrimary),
-                      foregroundColor: Theme.of(context).colorScheme.onPrimary,
-                    ),
-                    child: Text(widget.enterUrlText),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 

--- a/apps/enmeshed/lib/core/widgets/upload_file.dart
+++ b/apps/enmeshed/lib/core/widgets/upload_file.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:math';
 
 import 'package:enmeshed_runtime_bridge/enmeshed_runtime_bridge.dart';
 import 'package:enmeshed_types/enmeshed_types.dart';
@@ -79,7 +80,12 @@ class _UploadFileState extends State<UploadFile> {
             ),
             Flexible(
               child: Padding(
-                padding: EdgeInsets.only(left: 24, right: 24, bottom: MediaQuery.viewInsetsOf(context).bottom, top: 16),
+                padding: EdgeInsets.only(
+                  left: 24,
+                  right: 24,
+                  bottom: max(MediaQuery.viewPaddingOf(context).bottom, MediaQuery.viewInsetsOf(context).bottom) + 8,
+                  top: 16,
+                ),
                 child: SingleChildScrollView(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
@@ -136,7 +142,6 @@ class _UploadFileState extends State<UploadFile> {
                           ),
                         ],
                       ),
-                      Gaps.h24,
                     ],
                   ),
                 ),

--- a/apps/enmeshed/lib/drawer/debug_screen.dart
+++ b/apps/enmeshed/lib/drawer/debug_screen.dart
@@ -24,150 +24,152 @@ class DebugScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('DEBUG')),
-      body: SingleChildScrollView(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            FutureBuilder(
-              builder: (_, s) => !s.hasData ? const CircularProgressIndicator() : _CopyableText(title: 'Address: ', text: s.data!.value.address),
-              future: () async {
-                final accounts = await GetIt.I.get<EnmeshedRuntime>().accountServices.getAccounts();
-                final lastUsedAccount = accounts.reduce(
-                  (value, element) => (value.lastAccessedAt ?? '').compareTo(element.lastAccessedAt ?? '') == 1 ? value : element,
-                );
-                final session = GetIt.I.get<EnmeshedRuntime>().getSession(lastUsedAccount.id);
+      body: SafeArea(
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              FutureBuilder(
+                builder: (_, s) => !s.hasData ? const CircularProgressIndicator() : _CopyableText(title: 'Address: ', text: s.data!.value.address),
+                future: () async {
+                  final accounts = await GetIt.I.get<EnmeshedRuntime>().accountServices.getAccounts();
+                  final lastUsedAccount = accounts.reduce(
+                    (value, element) => (value.lastAccessedAt ?? '').compareTo(element.lastAccessedAt ?? '') == 1 ? value : element,
+                  );
+                  final session = GetIt.I.get<EnmeshedRuntime>().getSession(lastUsedAccount.id);
 
-                return session.transportServices.account.getIdentityInfo();
-              }(),
-            ),
-            FutureBuilder(
-              builder: (_, s) => !s.hasData ? const CircularProgressIndicator() : _CopyableText(title: 'Push Token: ', text: s.data!),
-              future: Push.instance.token.timeout(const Duration(seconds: 5)).catchError((_) => 'timeout', test: (e) => e is TimeoutException),
-            ),
-            if (kDebugMode) ...[
+                  return session.transportServices.account.getIdentityInfo();
+                }(),
+              ),
+              FutureBuilder(
+                builder: (_, s) => !s.hasData ? const CircularProgressIndicator() : _CopyableText(title: 'Push Token: ', text: s.data!),
+                future: Push.instance.token.timeout(const Duration(seconds: 5)).catchError((_) => 'timeout', test: (e) => e is TimeoutException),
+              ),
+              if (kDebugMode) ...[
+                const Divider(indent: 20, endIndent: 20, height: 20, thickness: 1.5),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+                  child: Text('Enter Password Popups', style: Theme.of(context).textTheme.titleLarge),
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+                  child: Wrap(
+                    spacing: 8,
+                    children: [
+                      for (int i = 4; i <= 16; i++)
+                        OutlinedButton(
+                          onPressed: () async {
+                            final pin = await context.push(
+                              '/enter-password-popup',
+                              extra: (passwordType: UIBridgePasswordType.pin, pinLength: i, attempt: 1),
+                            );
+
+                            if (!context.mounted) return;
+                            ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Entered PIN Code: $pin')));
+                          },
+                          child: Text('PIN$i'),
+                        ),
+                      OutlinedButton(
+                        onPressed: () async {
+                          final password = await context.push(
+                            '/enter-password-popup',
+                            extra: (passwordType: UIBridgePasswordType.password, pinLength: null, attempt: 1),
+                          );
+
+                          if (!context.mounted) return;
+                          ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Entered Password: $password')));
+                        },
+                        child: const Text('PW'),
+                      ),
+                    ],
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+                  child: Text('Enter Password Popups (Second attempt)', style: Theme.of(context).textTheme.titleLarge),
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+                  child: Wrap(
+                    spacing: 8,
+                    children: [
+                      for (int i = 4; i <= 16; i++)
+                        OutlinedButton(
+                          onPressed: () async {
+                            final pin = await context.push(
+                              '/enter-password-popup',
+                              extra: (passwordType: UIBridgePasswordType.pin, pinLength: i, attempt: 2),
+                            );
+
+                            if (!context.mounted) return;
+                            ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Entered PIN Code: $pin')));
+                          },
+                          child: Text('PIN$i'),
+                        ),
+                      OutlinedButton(
+                        onPressed: () async {
+                          final password = await context.push(
+                            '/enter-password-popup',
+                            extra: (passwordType: UIBridgePasswordType.password, pinLength: null, attempt: 2),
+                          );
+
+                          if (!context.mounted) return;
+                          ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Entered Password: $password')));
+                        },
+                        child: const Text('PW'),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
               const Divider(indent: 20, endIndent: 20, height: 20, thickness: 1.5),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
-                child: Text('Enter Password Popups', style: Theme.of(context).textTheme.titleLarge),
+                child: Text('Settings', style: Theme.of(context).textTheme.titleLarge),
               ),
               Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+                padding: const EdgeInsets.symmetric(horizontal: 20),
                 child: Wrap(
                   spacing: 8,
                   children: [
-                    for (int i = 4; i <= 16; i++)
+                    if (kDebugMode) ...[
                       OutlinedButton(
-                        onPressed: () async {
-                          final pin = await context.push(
-                            '/enter-password-popup',
-                            extra: (passwordType: UIBridgePasswordType.pin, pinLength: i, attempt: 1),
-                          );
-
-                          if (!context.mounted) return;
-                          ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Entered PIN Code: $pin')));
-                        },
-                        child: Text('PIN$i'),
+                        onPressed: () => DebugFeatures.show(
+                          context,
+                          availableFeatures: [
+                            const Feature('SHOW_TECHNICAL_MESSAGES', name: 'Show Technical Messages'),
+                            const Feature('DELETE_IDENTITY_NOW', name: 'Delete an Identity Immediately'),
+                            const Feature(
+                              'SHOW_ADDITIONAL_PUBLIC_RELATIONSHIP_TEMPLATE_REFERENCES',
+                              name: 'Show Additional Public Relationship Template References',
+                            ),
+                            const Feature('IDENTITY_RECOVERY_KITS', name: 'Identity Recovery Kits'),
+                          ],
+                        ),
+                        child: const Text('Feature Flags'),
                       ),
+                      OutlinedButton(
+                        onPressed: () async => _clearProfiles(context),
+                        child: const Text('Clear Profiles'),
+                      ),
+                    ],
                     OutlinedButton(
-                      onPressed: () async {
-                        final password = await context.push(
-                          '/enter-password-popup',
-                          extra: (passwordType: UIBridgePasswordType.password, pinLength: null, attempt: 1),
-                        );
-
-                        if (!context.mounted) return;
-                        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Entered Password: $password')));
-                      },
-                      child: const Text('PW'),
+                      onPressed: () => showModalBottomSheet<void>(
+                        context: context,
+                        isScrollControlled: true,
+                        builder: (context) => const SafeArea(minimum: EdgeInsets.only(bottom: 16), child: _PushDebugger()),
+                      ),
+                      child: const Text('Push Debugger'),
                     ),
-                  ],
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
-                child: Text('Enter Password Popups (Second attempt)', style: Theme.of(context).textTheme.titleLarge),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
-                child: Wrap(
-                  spacing: 8,
-                  children: [
-                    for (int i = 4; i <= 16; i++)
-                      OutlinedButton(
-                        onPressed: () async {
-                          final pin = await context.push(
-                            '/enter-password-popup',
-                            extra: (passwordType: UIBridgePasswordType.pin, pinLength: i, attempt: 2),
-                          );
-
-                          if (!context.mounted) return;
-                          ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Entered PIN Code: $pin')));
-                        },
-                        child: Text('PIN$i'),
-                      ),
                     OutlinedButton(
-                      onPressed: () async {
-                        final password = await context.push(
-                          '/enter-password-popup',
-                          extra: (passwordType: UIBridgePasswordType.password, pinLength: null, attempt: 2),
-                        );
-
-                        if (!context.mounted) return;
-                        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Entered Password: $password')));
-                      },
-                      child: const Text('PW'),
+                      onPressed: _extractAppDataAsZip,
+                      child: const Text('Export App Data'),
                     ),
                   ],
                 ),
               ),
             ],
-            const Divider(indent: 20, endIndent: 20, height: 20, thickness: 1.5),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
-              child: Text('Settings', style: Theme.of(context).textTheme.titleLarge),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 20),
-              child: Wrap(
-                spacing: 8,
-                children: [
-                  if (kDebugMode) ...[
-                    OutlinedButton(
-                      onPressed: () => DebugFeatures.show(
-                        context,
-                        availableFeatures: [
-                          const Feature('SHOW_TECHNICAL_MESSAGES', name: 'Show Technical Messages'),
-                          const Feature('DELETE_IDENTITY_NOW', name: 'Delete an Identity Immediately'),
-                          const Feature(
-                            'SHOW_ADDITIONAL_PUBLIC_RELATIONSHIP_TEMPLATE_REFERENCES',
-                            name: 'Show Additional Public Relationship Template References',
-                          ),
-                          const Feature('IDENTITY_RECOVERY_KITS', name: 'Identity Recovery Kits'),
-                        ],
-                      ),
-                      child: const Text('Feature Flags'),
-                    ),
-                    OutlinedButton(
-                      onPressed: () async => _clearProfiles(context),
-                      child: const Text('Clear Profiles'),
-                    ),
-                  ],
-                  OutlinedButton(
-                    onPressed: () => showModalBottomSheet<void>(
-                      context: context,
-                      isScrollControlled: true,
-                      builder: (context) => const SafeArea(minimum: EdgeInsets.only(bottom: 16), child: _PushDebugger()),
-                    ),
-                    child: const Text('Push Debugger'),
-                  ),
-                  OutlinedButton(
-                    onPressed: _extractAppDataAsZip,
-                    child: const Text('Export App Data'),
-                  ),
-                ],
-              ),
-            ),
-          ],
+          ),
         ),
       ),
     );

--- a/apps/enmeshed/lib/onboarding/onboarding_create_account.dart
+++ b/apps/enmeshed/lib/onboarding/onboarding_create_account.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
 import 'package:logger/logger.dart';
-import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
 import '/core/core.dart';
 
@@ -42,24 +41,11 @@ class _OnboardingCreateAccountState extends State<OnboardingCreateAccount> {
   }
 
   Future<void> _showEnterProfileNameModal() async {
-    final newProfileName = await WoltModalSheet.show<String?>(
+    final newProfileName = await showModalBottomSheet<String?>(
       context: context,
-      barrierDismissible: true,
-      enableDrag: true,
-      useSafeArea: false,
-      pageListBuilder: (context) => [
-        WoltModalSheetPage(
-          leadingNavBarWidget: Padding(
-            padding: const EdgeInsets.only(left: 24, top: 20),
-            child: Text(context.l10n.onboarding_enterProfileName, style: Theme.of(context).textTheme.titleLarge),
-          ),
-          trailingNavBarWidget: Padding(
-            padding: const EdgeInsets.only(right: 8),
-            child: IconButton(icon: const Icon(Icons.close), onPressed: () => context.pop()),
-          ),
-          child: const _EnterProfileNameDialog(),
-        ),
-      ],
+      showDragHandle: false,
+      isScrollControlled: true,
+      builder: (context) => const _EnterProfileNameDialog(),
     );
 
     if (newProfileName == null) return widget.goToOnboardingAccount();
@@ -116,43 +102,62 @@ class _EnterProfileNameDialogState extends State<_EnterProfileNameDialog> {
     final defaultProfileName = '${context.l10n.onboarding_defaultIdentityName} 1';
 
     return SafeArea(
-      minimum: const EdgeInsets.only(bottom: 24),
-      child: Padding(
-        padding: const EdgeInsets.only(top: 16, left: 24, right: 24),
-        child: Column(
-          children: [
-            TextField(
-              maxLength: MaxLength.profileName,
-              controller: _controller,
-              textCapitalization: TextCapitalization.sentences,
-              decoration: InputDecoration(
-                floatingLabelBehavior: FloatingLabelBehavior.never,
-                hintText: defaultProfileName,
-                suffixIcon: IconButton(
-                  onPressed: _controller.clear,
-                  icon: const Icon(Icons.cancel_outlined),
+      minimum: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(left: 24, top: 8, right: 8),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(context.l10n.onboarding_enterProfileName, style: Theme.of(context).textTheme.titleLarge),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: IconButton(icon: const Icon(Icons.close), onPressed: () => context.pop()),
                 ),
-                border: const OutlineInputBorder(
-                  borderRadius: BorderRadius.all(Radius.circular(8)),
-                ),
-                focusedBorder: OutlineInputBorder(
-                  borderSide: BorderSide(color: Theme.of(context).colorScheme.outline),
-                  borderRadius: const BorderRadius.all(Radius.circular(8)),
-                ),
-              ),
-              onSubmitted: (text) => context.pop(text),
+              ],
             ),
-            Gaps.h16,
-            Align(
-              alignment: Alignment.centerRight,
-              child: FilledButton(
-                onPressed: () => context.pop(_controller.text.isEmpty ? defaultProfileName : _controller.text),
-                style: FilledButton.styleFrom(minimumSize: const Size(100, 36)),
-                child: Text(context.l10n.onboarding_acceptProfileName),
-              ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(top: 16, left: 24, right: 24, bottom: 8),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextField(
+                  maxLength: MaxLength.profileName,
+                  controller: _controller,
+                  textCapitalization: TextCapitalization.sentences,
+                  decoration: InputDecoration(
+                    floatingLabelBehavior: FloatingLabelBehavior.never,
+                    hintText: defaultProfileName,
+                    suffixIcon: IconButton(
+                      onPressed: _controller.clear,
+                      icon: const Icon(Icons.cancel_outlined),
+                    ),
+                    border: const OutlineInputBorder(
+                      borderRadius: BorderRadius.all(Radius.circular(8)),
+                    ),
+                    focusedBorder: OutlineInputBorder(
+                      borderSide: BorderSide(color: Theme.of(context).colorScheme.outline),
+                      borderRadius: const BorderRadius.all(Radius.circular(8)),
+                    ),
+                  ),
+                  onSubmitted: (text) => context.pop(text),
+                ),
+                Gaps.h16,
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: FilledButton(
+                    onPressed: () => context.pop(_controller.text.isEmpty ? defaultProfileName : _controller.text),
+                    style: FilledButton.styleFrom(minimumSize: const Size(100, 36)),
+                    child: Text(context.l10n.onboarding_acceptProfileName),
+                  ),
+                ),
+              ],
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/apps/enmeshed/lib/onboarding/onboarding_create_account.dart
+++ b/apps/enmeshed/lib/onboarding/onboarding_create_account.dart
@@ -115,41 +115,44 @@ class _EnterProfileNameDialogState extends State<_EnterProfileNameDialog> {
   Widget build(BuildContext context) {
     final defaultProfileName = '${context.l10n.onboarding_defaultIdentityName} 1';
 
-    return Padding(
-      padding: const EdgeInsets.only(top: 16, bottom: 24, left: 24, right: 24),
-      child: Column(
-        children: [
-          TextField(
-            maxLength: MaxLength.profileName,
-            controller: _controller,
-            textCapitalization: TextCapitalization.sentences,
-            decoration: InputDecoration(
-              floatingLabelBehavior: FloatingLabelBehavior.never,
-              hintText: defaultProfileName,
-              suffixIcon: IconButton(
-                onPressed: _controller.clear,
-                icon: const Icon(Icons.cancel_outlined),
+    return SafeArea(
+      minimum: const EdgeInsets.only(bottom: 24),
+      child: Padding(
+        padding: const EdgeInsets.only(top: 16, left: 24, right: 24),
+        child: Column(
+          children: [
+            TextField(
+              maxLength: MaxLength.profileName,
+              controller: _controller,
+              textCapitalization: TextCapitalization.sentences,
+              decoration: InputDecoration(
+                floatingLabelBehavior: FloatingLabelBehavior.never,
+                hintText: defaultProfileName,
+                suffixIcon: IconButton(
+                  onPressed: _controller.clear,
+                  icon: const Icon(Icons.cancel_outlined),
+                ),
+                border: const OutlineInputBorder(
+                  borderRadius: BorderRadius.all(Radius.circular(8)),
+                ),
+                focusedBorder: OutlineInputBorder(
+                  borderSide: BorderSide(color: Theme.of(context).colorScheme.outline),
+                  borderRadius: const BorderRadius.all(Radius.circular(8)),
+                ),
               ),
-              border: const OutlineInputBorder(
-                borderRadius: BorderRadius.all(Radius.circular(8)),
-              ),
-              focusedBorder: OutlineInputBorder(
-                borderSide: BorderSide(color: Theme.of(context).colorScheme.outline),
-                borderRadius: const BorderRadius.all(Radius.circular(8)),
+              onSubmitted: (text) => context.pop(text),
+            ),
+            Gaps.h16,
+            Align(
+              alignment: Alignment.centerRight,
+              child: FilledButton(
+                onPressed: () => context.pop(_controller.text.isEmpty ? defaultProfileName : _controller.text),
+                style: FilledButton.styleFrom(minimumSize: const Size(100, 36)),
+                child: Text(context.l10n.onboarding_acceptProfileName),
               ),
             ),
-            onSubmitted: (text) => context.pop(text),
-          ),
-          Gaps.h16,
-          Align(
-            alignment: Alignment.centerRight,
-            child: FilledButton(
-              onPressed: () => context.pop(_controller.text.isEmpty ? defaultProfileName : _controller.text),
-              style: FilledButton.styleFrom(minimumSize: const Size(100, 36)),
-              child: Text(context.l10n.onboarding_acceptProfileName),
-            ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/apps/enmeshed/lib/onboarding/onboarding_information.dart
+++ b/apps/enmeshed/lib/onboarding/onboarding_information.dart
@@ -1,4 +1,4 @@
-import 'dart:math';
+import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
@@ -76,47 +76,44 @@ class _OnboardingInformationState extends State<OnboardingInformation> {
             ),
           ),
           Container(
-            height: 80,
             color: Theme.of(context).colorScheme.primaryContainer.withValues(alpha: 0.6),
-            child: Padding(
-              padding: EdgeInsets.only(left: 24, right: 24, top: 6, bottom: MediaQuery.viewInsetsOf(context).bottom + 30),
-              child: Stack(
-                alignment: Alignment.center,
-                children: [
-                  Visibility(
-                    visible: _currentPageIndex < pages.length - 1,
-                    child: Align(
-                      alignment: Alignment.centerLeft,
-                      child: TextButton(
-                        onPressed: widget.goToOnboardingLegalTexts,
-                        child: Text(context.l10n.skip),
-                      ),
+            padding: EdgeInsets.only(left: 24, right: 24, top: 6, bottom: MediaQuery.viewPaddingOf(context).bottom),
+            child: Stack(
+              alignment: Alignment.center,
+              children: [
+                Visibility(
+                  visible: _currentPageIndex < pages.length - 1,
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: TextButton(
+                      onPressed: widget.goToOnboardingLegalTexts,
+                      child: Text(context.l10n.skip),
                     ),
                   ),
-                  SmoothPageIndicator(
-                    controller: _pageController,
-                    count: pages.length,
-                    effect: SlideEffect(
-                      dotHeight: 10,
-                      dotWidth: 10,
-                      activeDotColor: Theme.of(context).colorScheme.primary,
-                      dotColor: Theme.of(context).colorScheme.primaryContainer,
-                    ),
-                    onDotClicked: (index) {
-                      _pageController.animateToPage(index, duration: const Duration(milliseconds: 300), curve: Curves.easeIn);
-                    },
+                ),
+                SmoothPageIndicator(
+                  controller: _pageController,
+                  count: pages.length,
+                  effect: SlideEffect(
+                    dotHeight: 10,
+                    dotWidth: 10,
+                    activeDotColor: Theme.of(context).colorScheme.primary,
+                    dotColor: Theme.of(context).colorScheme.primaryContainer,
                   ),
-                  Align(
-                    alignment: Alignment.centerRight,
-                    child: FilledButton(
-                      onPressed: _currentPageIndex == pages.length - 1
-                          ? widget.goToOnboardingLegalTexts
-                          : () => _pageController.nextPage(duration: const Duration(milliseconds: 300), curve: Curves.easeIn),
-                      child: Text(context.l10n.next),
-                    ),
+                  onDotClicked: (index) {
+                    _pageController.animateToPage(index, duration: const Duration(milliseconds: 300), curve: Curves.easeIn);
+                  },
+                ),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: FilledButton(
+                    onPressed: _currentPageIndex == pages.length - 1
+                        ? widget.goToOnboardingLegalTexts
+                        : () => _pageController.nextPage(duration: const Duration(milliseconds: 300), curve: Curves.easeIn),
+                    child: Text(context.l10n.next),
                   ),
-                ],
-              ),
+                ),
+              ],
             ),
           ),
         ],
@@ -203,12 +200,12 @@ class _OnboardingPageState extends State<_OnboardingPage> {
       if (lineWidth + wordWidth <= maxWidth) {
         lineWidth += wordWidth;
       } else {
-        maxLineWidth = max(maxLineWidth, lineWidth);
+        maxLineWidth = math.max(maxLineWidth, lineWidth);
         lineWidth = wordWidth;
       }
     }
 
-    return max(maxLineWidth, lineWidth);
+    return math.max(maxLineWidth, lineWidth);
   }
 
   double _calculateWordWidth(String text, TextStyle style) {

--- a/apps/enmeshed/lib/onboarding/onboarding_welcome.dart
+++ b/apps/enmeshed/lib/onboarding/onboarding_welcome.dart
@@ -13,8 +13,9 @@ class OnboardingWelcome extends StatelessWidget {
     final screenHeight = MediaQuery.sizeOf(context).height;
 
     return SafeArea(
+      minimum: const EdgeInsets.only(bottom: 24),
       child: Padding(
-        padding: EdgeInsets.only(left: 24, right: 24, bottom: MediaQuery.viewInsetsOf(context).bottom + 16),
+        padding: const EdgeInsets.only(left: 24, right: 24),
         child: Column(
           children: [
             Expanded(

--- a/apps/enmeshed/lib/profiles/device/device_detail/widgets/delete_device_sheet.dart
+++ b/apps/enmeshed/lib/profiles/device/device_detail/widgets/delete_device_sheet.dart
@@ -25,7 +25,7 @@ class _DeleteDeviceSheetState extends State<DeleteDeviceSheet> {
     return Stack(
       children: [
         Padding(
-          padding: EdgeInsets.only(top: 8, left: 24, right: 8, bottom: MediaQuery.viewInsetsOf(context).bottom + 24),
+          padding: EdgeInsets.only(top: 8, left: 24, right: 8, bottom: MediaQuery.paddingOf(context).bottom),
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [

--- a/apps/enmeshed/lib/profiles/device/device_detail/widgets/edit_device.dart
+++ b/apps/enmeshed/lib/profiles/device/device_detail/widgets/edit_device.dart
@@ -56,74 +56,89 @@ class _EditDeviceState extends State<EditDevice> {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: EdgeInsets.only(top: 8, left: 24, right: 24, bottom: MediaQuery.viewInsetsOf(context).bottom + 24),
-      child: Wrap(
-        spacing: 8,
-        children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(context.l10n.devices_edit, style: Theme.of(context).textTheme.titleLarge),
-              IconButton(
-                onPressed: _loading ? null : () => context.pop(),
-                icon: const Icon(Icons.close),
-              ),
-            ],
-          ),
-          Gaps.h16,
-          TextField(
-            enabled: !_loading,
-            focusNode: _nameFocusNode,
-            controller: _nameController,
-            maxLength: MaxLength.deviceName,
-            textCapitalization: TextCapitalization.sentences,
-            decoration: InputDecoration(
-              labelText: '${context.l10n.name}*',
-              border: OutlineInputBorder(
-                borderRadius: const BorderRadius.all(Radius.circular(8)),
-                borderSide: BorderSide(color: Theme.of(context).colorScheme.outline),
-              ),
-              focusedBorder: OutlineInputBorder(
-                borderRadius: const BorderRadius.all(Radius.circular(8)),
-                borderSide: BorderSide(color: Theme.of(context).colorScheme.primary),
+    return SafeArea(
+      child: Padding(
+        padding: EdgeInsets.only(bottom: MediaQuery.viewInsetsOf(context).bottom),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          spacing: 8,
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(top: 8, left: 24, right: 16),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(context.l10n.devices_edit, style: Theme.of(context).textTheme.titleLarge),
+                  IconButton(
+                    onPressed: _loading ? null : () => context.pop(),
+                    icon: const Icon(Icons.close),
+                  ),
+                ],
               ),
             ),
-            onSubmitted: (value) => value.isEmpty ? _nameFocusNode.requestFocus() : _descriptionFocusNode.requestFocus(),
-          ),
-          Gaps.h8,
-          TextField(
-            enabled: !_loading,
-            focusNode: _descriptionFocusNode,
-            controller: _descriptionController,
-            maxLength: MaxLength.deviceDescription,
-            textCapitalization: TextCapitalization.sentences,
-            decoration: InputDecoration(
-              labelText: context.l10n.devices_edit_description,
-              border: OutlineInputBorder(
-                borderRadius: const BorderRadius.all(Radius.circular(8)),
-                borderSide: BorderSide(color: Theme.of(context).colorScheme.outline),
-              ),
-              focusedBorder: OutlineInputBorder(
-                borderRadius: const BorderRadius.all(Radius.circular(8)),
-                borderSide: BorderSide(color: Theme.of(context).colorScheme.primary),
+            Gaps.h16,
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: TextField(
+                enabled: !_loading,
+                focusNode: _nameFocusNode,
+                controller: _nameController,
+                maxLength: MaxLength.deviceName,
+                textCapitalization: TextCapitalization.sentences,
+                decoration: InputDecoration(
+                  labelText: '${context.l10n.name}*',
+                  border: OutlineInputBorder(
+                    borderRadius: const BorderRadius.all(Radius.circular(8)),
+                    borderSide: BorderSide(color: Theme.of(context).colorScheme.outline),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: const BorderRadius.all(Radius.circular(8)),
+                    borderSide: BorderSide(color: Theme.of(context).colorScheme.primary),
+                  ),
+                ),
+                onSubmitted: (value) => value.isEmpty ? _nameFocusNode.requestFocus() : _descriptionFocusNode.requestFocus(),
               ),
             ),
-            onSubmitted: (value) => _confirmEnabled ? _save() : _nameFocusNode.requestFocus(),
-          ),
-          Gaps.h8,
-          Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              OutlinedButton(onPressed: _loading ? null : () => context.pop(), child: Text(context.l10n.cancel)),
-              Gaps.w8,
-              FilledButton(
-                onPressed: _confirmEnabled && !_loading ? _save : null,
-                child: Text(context.l10n.save),
+            Gaps.h8,
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: TextField(
+                enabled: !_loading,
+                focusNode: _descriptionFocusNode,
+                controller: _descriptionController,
+                maxLength: MaxLength.deviceDescription,
+                textCapitalization: TextCapitalization.sentences,
+                decoration: InputDecoration(
+                  labelText: context.l10n.devices_edit_description,
+                  border: OutlineInputBorder(
+                    borderRadius: const BorderRadius.all(Radius.circular(8)),
+                    borderSide: BorderSide(color: Theme.of(context).colorScheme.outline),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: const BorderRadius.all(Radius.circular(8)),
+                    borderSide: BorderSide(color: Theme.of(context).colorScheme.primary),
+                  ),
+                ),
+                onSubmitted: (value) => _confirmEnabled ? _save() : _nameFocusNode.requestFocus(),
               ),
-            ],
-          ),
-        ],
+            ),
+            Gaps.h8,
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 24),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  OutlinedButton(onPressed: _loading ? null : () => context.pop(), child: Text(context.l10n.cancel)),
+                  Gaps.w8,
+                  FilledButton(
+                    onPressed: _confirmEnabled && !_loading ? _save : null,
+                    child: Text(context.l10n.save),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/apps/enmeshed/lib/profiles/device/devices_overview/widgets/create_device.dart
+++ b/apps/enmeshed/lib/profiles/device/devices_overview/widgets/create_device.dart
@@ -53,7 +53,7 @@ class _CreateDeviceState extends State<CreateDevice> {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: EdgeInsets.only(top: 8, left: 24, right: 24, bottom: MediaQuery.viewInsetsOf(context).bottom + 24),
+      padding: EdgeInsets.only(top: 8, left: 24, right: 24, bottom: MediaQuery.viewPaddingOf(context).bottom),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -95,11 +95,14 @@ class _CreateDeviceState extends State<CreateDevice> {
             onSubmitted: (value) => _confirmEnabled ? _save() : _nameFocusNode.requestFocus(),
           ),
           Gaps.h8,
-          Align(
-            alignment: Alignment.centerRight,
-            child: FilledButton(
-              onPressed: _confirmEnabled ? _save : null,
-              child: Text(context.l10n.next),
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: FilledButton(
+                onPressed: _confirmEnabled ? _save : null,
+                child: Text(context.l10n.next),
+              ),
             ),
           ),
         ],

--- a/apps/enmeshed/lib/profiles/device/widgets/device_onboarding.dart
+++ b/apps/enmeshed/lib/profiles/device/widgets/device_onboarding.dart
@@ -233,9 +233,9 @@ class _DeviceOnboardingUrl extends StatelessWidget {
                       )
                     : Column(
                         mainAxisSize: MainAxisSize.min,
+                        spacing: 24,
                         children: [
-                          Text(link, maxLines: 4, overflow: TextOverflow.ellipsis),
-                          Gaps.h24,
+                          Flexible(child: Text(link, maxLines: 40, overflow: TextOverflow.ellipsis)),
                           OutlinedButton.icon(
                             onPressed: () => Clipboard.setData(ClipboardData(text: link)),
                             icon: const Icon(Icons.file_copy_outlined),

--- a/apps/enmeshed/lib/profiles/device/widgets/device_onboarding.dart
+++ b/apps/enmeshed/lib/profiles/device/widgets/device_onboarding.dart
@@ -71,7 +71,7 @@ class _DeviceOnboardingState extends State<DeviceOnboarding> with SingleTickerPr
     final isExpired = DateTime.now().isAfter(expiryTime);
 
     return Padding(
-      padding: EdgeInsets.only(bottom: MediaQuery.viewInsetsOf(context).bottom + 36),
+      padding: EdgeInsets.only(bottom: MediaQuery.paddingOf(context).bottom),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
@@ -94,7 +94,7 @@ class _DeviceOnboardingState extends State<DeviceOnboarding> with SingleTickerPr
             ),
           ),
           Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 24),
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
             child: isExpired
                 ? Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/apps/enmeshed/lib/profiles/device/widgets/device_onboarding.dart
+++ b/apps/enmeshed/lib/profiles/device/widgets/device_onboarding.dart
@@ -224,27 +224,26 @@ class _DeviceOnboardingUrl extends StatelessWidget {
           Expanded(
             child: Padding(
               padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 24),
-              child: isExpired
-                  ? Center(
-                      child: FilledButton.icon(
+              child: Center(
+                child: isExpired
+                    ? FilledButton.icon(
                         onPressed: getDeviceToken,
                         icon: const Icon(Icons.refresh),
                         label: Text(context.l10n.devices_code_generateUrl),
+                      )
+                    : Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(link, maxLines: 4, overflow: TextOverflow.ellipsis),
+                          Gaps.h24,
+                          OutlinedButton.icon(
+                            onPressed: () => Clipboard.setData(ClipboardData(text: link)),
+                            icon: const Icon(Icons.file_copy_outlined),
+                            label: Text(context.l10n.devices_code_copy),
+                          ),
+                        ],
                       ),
-                    )
-                  : Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Gaps.h32,
-                        Text(link),
-                        Gaps.h24,
-                        OutlinedButton.icon(
-                          onPressed: () => Clipboard.setData(ClipboardData(text: link)),
-                          icon: const Icon(Icons.file_copy_outlined),
-                          label: Text(context.l10n.devices_code_copy),
-                        ),
-                      ],
-                    ),
+              ),
             ),
           ),
         ],

--- a/apps/enmeshed/lib/profiles/device/widgets/device_onboarding.dart
+++ b/apps/enmeshed/lib/profiles/device/widgets/device_onboarding.dart
@@ -168,36 +168,34 @@ class _DeviceOnboardingQRCode extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           Text(textAlign: TextAlign.center, context.l10n.devices_code_qrDescription),
-          Gaps.h16,
-          Stack(
-            children: [
-              Center(
-                child: QrImageView(
-                  data: link,
-                  semanticsLabel: context.l10n.devices_code_qrSemanticsLabel,
-                  eyeStyle: QrEyeStyle(
-                    eyeShape: QrEyeShape.square,
-                    color: isExpired ? Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.2) : Theme.of(context).colorScheme.scrim,
+          Expanded(
+            child: Stack(
+              children: [
+                Center(
+                  child: QrImageView(
+                    data: link,
+                    semanticsLabel: context.l10n.devices_code_qrSemanticsLabel,
+                    eyeStyle: QrEyeStyle(
+                      eyeShape: QrEyeShape.square,
+                      color: isExpired ? Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.2) : Theme.of(context).colorScheme.scrim,
+                    ),
+                    dataModuleStyle: QrDataModuleStyle(
+                      dataModuleShape: QrDataModuleShape.square,
+                      color: isExpired ? Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.2) : Theme.of(context).colorScheme.scrim,
+                    ),
+                    size: 200,
                   ),
-                  dataModuleStyle: QrDataModuleStyle(
-                    dataModuleShape: QrDataModuleShape.square,
-                    color: isExpired ? Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.2) : Theme.of(context).colorScheme.scrim,
-                  ),
-                  size: 200,
                 ),
-              ),
-              if (isExpired)
-                SizedBox(
-                  height: 200,
-                  child: Center(
+                if (isExpired)
+                  Center(
                     child: FilledButton.icon(
                       onPressed: getDeviceToken,
                       icon: const Icon(Icons.refresh),
                       label: Text(context.l10n.devices_code_generateQr),
                     ),
                   ),
-                ),
-            ],
+              ],
+            ),
           ),
         ],
       ),
@@ -223,31 +221,31 @@ class _DeviceOnboardingUrl extends StatelessWidget {
         children: [
           Text(textAlign: TextAlign.center, context.l10n.devices_code_urlDescription),
           Gaps.h16,
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 24),
-            child: isExpired
-                ? SizedBox(
-                    height: 200,
-                    child: Center(
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 24),
+              child: isExpired
+                  ? Center(
                       child: FilledButton.icon(
                         onPressed: getDeviceToken,
                         icon: const Icon(Icons.refresh),
                         label: Text(context.l10n.devices_code_generateUrl),
                       ),
+                    )
+                  : Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Gaps.h32,
+                        Text(link),
+                        Gaps.h24,
+                        OutlinedButton.icon(
+                          onPressed: () => Clipboard.setData(ClipboardData(text: link)),
+                          icon: const Icon(Icons.file_copy_outlined),
+                          label: Text(context.l10n.devices_code_copy),
+                        ),
+                      ],
                     ),
-                  )
-                : Column(
-                    children: [
-                      Gaps.h32,
-                      Text(link),
-                      Gaps.h24,
-                      OutlinedButton.icon(
-                        onPressed: () => Clipboard.setData(ClipboardData(text: link)),
-                        icon: const Icon(Icons.file_copy_outlined),
-                        label: Text(context.l10n.devices_code_copy),
-                      ),
-                    ],
-                  ),
+            ),
           ),
         ],
       ),

--- a/apps/enmeshed/lib/profiles/device/widgets/device_onboarding_safety_note.dart
+++ b/apps/enmeshed/lib/profiles/device/widgets/device_onboarding_safety_note.dart
@@ -10,7 +10,7 @@ class DeviceOnboardingSafetyNote extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: EdgeInsets.only(left: 24, right: 24, bottom: MediaQuery.viewInsetsOf(context).bottom + 24),
+      padding: EdgeInsets.only(left: 24, right: 24, bottom: MediaQuery.viewPaddingOf(context).bottom),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/apps/enmeshed/lib/profiles/device/widgets/device_onboarding_success.dart
+++ b/apps/enmeshed/lib/profiles/device/widgets/device_onboarding_success.dart
@@ -10,7 +10,7 @@ class DeviceOnboardingSuccess extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: EdgeInsets.only(left: 24, right: 24, top: 16, bottom: MediaQuery.viewInsetsOf(context).bottom + 24),
+      padding: EdgeInsets.only(left: 24, right: 24, top: 16, bottom: MediaQuery.viewPaddingOf(context).bottom),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [

--- a/apps/enmeshed/lib/profiles/profile/modals/delete_profile/delete_profile_and_choose_next.dart
+++ b/apps/enmeshed/lib/profiles/profile/modals/delete_profile/delete_profile_and_choose_next.dart
@@ -100,7 +100,7 @@ class _Error extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: EdgeInsets.only(left: 24, right: 24, top: 24, bottom: MediaQuery.viewInsetsOf(context).bottom + 24),
+      padding: EdgeInsets.only(left: 24, right: 24, top: 24, bottom: MediaQuery.viewPaddingOf(context).bottom + 24),
       child: Column(
         children: [
           Icon(Icons.cancel, size: 160, color: Theme.of(context).colorScheme.error),
@@ -133,7 +133,7 @@ class _Loading extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: EdgeInsets.only(left: 24, right: 24, top: 24, bottom: MediaQuery.viewInsetsOf(context).bottom + 48),
+      padding: EdgeInsets.only(left: 24, right: 24, top: 24, bottom: MediaQuery.viewPaddingOf(context).bottom + 48),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
@@ -152,7 +152,7 @@ class _Empty extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: EdgeInsets.only(left: 24, right: 24, top: 24, bottom: MediaQuery.viewInsetsOf(context).bottom + 24),
+      padding: EdgeInsets.only(left: 24, right: 24, top: 24, bottom: MediaQuery.viewPaddingOf(context).bottom + 24),
       child: Column(
         children: [
           Icon(Icons.check_circle_rounded, size: 160, color: context.customColors.success),
@@ -182,7 +182,7 @@ class _AccountsAvailable extends StatelessWidget {
   Widget build(BuildContext context) {
     return SingleChildScrollView(
       child: Padding(
-        padding: EdgeInsets.only(left: 24, right: 24, top: 24, bottom: MediaQuery.viewInsetsOf(context).bottom + 24),
+        padding: EdgeInsets.only(left: 24, right: 24, top: 24, bottom: MediaQuery.viewPaddingOf(context).bottom + 24),
         child: Column(
           children: [
             Icon(Icons.check_circle_rounded, size: 160, color: context.customColors.success),

--- a/apps/enmeshed/lib/profiles/profile/modals/delete_profile/delete_profile_or_identity.dart
+++ b/apps/enmeshed/lib/profiles/profile/modals/delete_profile/delete_profile_or_identity.dart
@@ -27,7 +27,7 @@ class DeleteProfileOrIdentity extends StatelessWidget {
       canPop: false,
       onPopInvokedWithResult: (_, __) => cancel(),
       child: Padding(
-        padding: EdgeInsets.only(left: 24, right: 24, bottom: MediaQuery.viewInsetsOf(context).bottom + 24),
+        padding: EdgeInsets.only(left: 24, right: 24, bottom: MediaQuery.viewPaddingOf(context).bottom + 16),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [

--- a/apps/enmeshed/lib/profiles/profile/modals/delete_profile/should_delete_identity.dart
+++ b/apps/enmeshed/lib/profiles/profile/modals/delete_profile/should_delete_identity.dart
@@ -26,7 +26,7 @@ class ShouldDeleteIdentity extends StatelessWidget {
       canPop: false,
       onPopInvokedWithResult: (_, __) => cancel(),
       child: Padding(
-        padding: EdgeInsets.only(left: 24, right: 24, top: 16, bottom: MediaQuery.viewInsetsOf(context).bottom + 24),
+        padding: EdgeInsets.only(left: 24, right: 24, top: 16, bottom: MediaQuery.viewPaddingOf(context).bottom + 16),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [

--- a/apps/enmeshed/lib/profiles/profile/modals/delete_profile/should_delete_profile.dart
+++ b/apps/enmeshed/lib/profiles/profile/modals/delete_profile/should_delete_profile.dart
@@ -31,7 +31,7 @@ class ShouldDeleteProfile extends StatelessWidget {
       canPop: false,
       onPopInvokedWithResult: (_, __) => cancel(),
       child: Padding(
-        padding: EdgeInsets.only(left: 24, right: 24, top: 16, bottom: MediaQuery.viewInsetsOf(context).bottom + 24),
+        padding: EdgeInsets.only(left: 24, right: 24, top: 16, bottom: MediaQuery.viewPaddingOf(context).bottom + 16),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [

--- a/apps/enmeshed/lib/profiles/profile/modals/edit_profile/edit_profile.dart
+++ b/apps/enmeshed/lib/profiles/profile/modals/edit_profile/edit_profile.dart
@@ -56,7 +56,7 @@ class _EditProfileState extends State<EditProfile> {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: EdgeInsets.only(left: 24, right: 24, bottom: MediaQuery.viewInsetsOf(context).bottom + 24),
+      padding: EdgeInsets.only(left: 24, right: 24, bottom: MediaQuery.paddingOf(context).bottom),
       child: Column(
         children: [
           ChangeProfilePicture(
@@ -90,19 +90,22 @@ class _EditProfileState extends State<EditProfile> {
             onSubmitted: (_) => _confirmEnabled ? _confirm() : _focusNode.requestFocus(),
           ),
           Gaps.h24,
-          Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              OutlinedButton(
-                onPressed: () => context.pop(),
-                child: Text(context.l10n.cancel),
-              ),
-              Gaps.w8,
-              FilledButton(
-                onPressed: _confirmEnabled ? _confirm : null,
-                child: Text(context.l10n.save),
-              ),
-            ],
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            child: Row(
+              spacing: 8,
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                OutlinedButton(
+                  onPressed: () => context.pop(),
+                  child: Text(context.l10n.cancel),
+                ),
+                FilledButton(
+                  onPressed: _confirmEnabled ? _confirm : null,
+                  child: Text(context.l10n.save),
+                ),
+              ],
+            ),
           ),
         ],
       ),

--- a/apps/enmeshed/lib/profiles/profile/modals/edit_profile/saving_profile.dart
+++ b/apps/enmeshed/lib/profiles/profile/modals/edit_profile/saving_profile.dart
@@ -10,7 +10,7 @@ class SavingProfile extends StatelessWidget {
     return PopScope(
       canPop: false,
       child: Padding(
-        padding: EdgeInsets.only(left: 24, right: 24, top: 24, bottom: MediaQuery.viewInsetsOf(context).bottom + 48),
+        padding: EdgeInsets.only(left: 24, right: 24, top: 24, bottom: MediaQuery.paddingOf(context).bottom),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [

--- a/apps/enmeshed/lib/profiles/profile/widgets/create_profile.dart
+++ b/apps/enmeshed/lib/profiles/profile/widgets/create_profile.dart
@@ -1,3 +1,4 @@
+import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:enmeshed_runtime_bridge/enmeshed_runtime_bridge.dart';
@@ -51,7 +52,12 @@ class _CreateProfileState extends State<CreateProfile> {
     return Stack(
       children: [
         Padding(
-          padding: EdgeInsets.only(top: 16, left: 24, right: 24, bottom: MediaQuery.paddingOf(context).bottom),
+          padding: EdgeInsets.only(
+            top: 16,
+            left: 24,
+            right: 24,
+            bottom: max(MediaQuery.viewInsetsOf(context).bottom, MediaQuery.viewPaddingOf(context).bottom),
+          ),
           child: Wrap(
             spacing: 8,
             children: [

--- a/apps/enmeshed/lib/profiles/profile/widgets/create_profile.dart
+++ b/apps/enmeshed/lib/profiles/profile/widgets/create_profile.dart
@@ -32,14 +32,17 @@ class _CreateProfileState extends State<CreateProfile> {
 
   @override
   void initState() {
+    super.initState();
+
     _controller.addListener(() => setState(() {}));
     _focusNode.requestFocus();
-    super.initState();
   }
 
   @override
   void dispose() {
     _controller.dispose();
+    _focusNode.dispose();
+
     super.dispose();
   }
 
@@ -48,7 +51,7 @@ class _CreateProfileState extends State<CreateProfile> {
     return Stack(
       children: [
         Padding(
-          padding: EdgeInsets.only(top: 16, left: 24, right: 24, bottom: MediaQuery.viewInsetsOf(context).bottom + 24),
+          padding: EdgeInsets.only(top: 16, left: 24, right: 24, bottom: MediaQuery.paddingOf(context).bottom),
           child: Wrap(
             spacing: 8,
             children: [
@@ -97,15 +100,18 @@ class _CreateProfileState extends State<CreateProfile> {
                 ),
                 onSubmitted: (_) => _confirmEnabled ? _confirm() : _focusNode.requestFocus(),
               ),
-              Gaps.h16,
-              Align(
-                alignment: Alignment.centerRight,
-                child: FilledButton(
-                  onPressed: _confirmEnabled ? _confirm : null,
-                  style: OutlinedButton.styleFrom(
-                    minimumSize: const Size(100, 36),
+              Gaps.h8,
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                child: Align(
+                  alignment: Alignment.centerRight,
+                  child: FilledButton(
+                    onPressed: _confirmEnabled ? _confirm : null,
+                    style: OutlinedButton.styleFrom(
+                      minimumSize: const Size(100, 36),
+                    ),
+                    child: Text(context.l10n.profile_create),
                   ),
-                  child: Text(context.l10n.profile_create),
                 ),
               ),
             ],


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

There were multiple issues that caused the app to overlap system components:

There are two types of things that can overlap our app
- insets -> keyboard
- padding -> notch / navigation bar + rail

In most of these cases we just used insets when having a text field, but completely ignored that there could be a padding. This worked kind of ok for navigation rails - because we just added 24px distance to the bottom, as I know now this was just an ugly workaround and disguised the actual issue.

This completely blew up for people having the navigation bar (buttons on android) enabled, when we enabled edge-to-edge mode.


