### PR TITLE
Deserializing a TransferFileOwnershipAcceptResponseItem throws an error

### DIFF
--- a/packages/enmeshed_types/lib/src/contents/response_item/accept_response_item.dart
+++ b/packages/enmeshed_types/lib/src/contents/response_item/accept_response_item.dart
@@ -16,6 +16,7 @@ class AcceptResponseItem extends ResponseItemDerivation {
       'ReadAttributeAcceptResponseItem' => ReadAttributeAcceptResponseItem.fromJson(json),
       'RegisterAttributeListenerAcceptResponseItem' => RegisterAttributeListenerAcceptResponseItem.fromJson(json),
       'FreeTextAcceptResponseItem' => FreeTextAcceptResponseItem.fromJson(json),
+      'TransferFileOwnershipAcceptResponseItem' => TransferFileOwnershipAcceptResponseItem.fromJson(json),
       'AttributeAlreadySharedAcceptResponseItem' => AttributeAlreadySharedAcceptResponseItem.fromJson(json),
       'AttributeSuccessionAcceptResponseItem' => AttributeSuccessionAcceptResponseItem.fromJson(json),
       _ => throw Exception('Unknown type: $type'),


### PR DESCRIPTION

# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

<!-- # Description -->
