### PR TITLE
Android navigation is dark in dark mode

### DIFF
--- a/apps/enmeshed/lib/main.dart
+++ b/apps/enmeshed/lib/main.dart
@@ -498,7 +498,6 @@ class EnmeshedApp extends StatelessWidget with WatchItMixin {
     return Features(
       child: MaterialApp.router(
         routerConfig: _router,
-
         debugShowCheckedModeBanner: false,
         themeMode: themeSetting.themeMode,
         theme: lightTheme,

--- a/apps/enmeshed/lib/main.dart
+++ b/apps/enmeshed/lib/main.dart
@@ -495,38 +495,28 @@ class EnmeshedApp extends StatelessWidget with WatchItMixin {
 
     final themeSetting = watchValue((ThemeModeModel x) => x.notifier);
 
-    return AnnotatedRegion<SystemUiOverlayStyle>(
-      value: SystemUiOverlayStyle(
-        statusBarColor: Colors.transparent,
-        systemNavigationBarDividerColor: Colors.transparent,
-        systemNavigationBarColor: Colors.transparent,
-        systemNavigationBarContrastEnforced: false,
-        systemNavigationBarIconBrightness: Theme.of(context).brightness.opposite,
-        statusBarBrightness: Theme.of(context).brightness,
-        statusBarIconBrightness: Theme.of(context).brightness.opposite,
-      ),
-      child: Features(
-        child: MaterialApp.router(
-          routerConfig: _router,
-          debugShowCheckedModeBanner: false,
-          themeMode: themeSetting.themeMode,
-          theme: lightTheme,
-          darkTheme: themeSetting.amoled ? amoledTheme : darkTheme,
-          highContrastTheme: highContrastTheme,
-          highContrastDarkTheme: highContrastDarkTheme,
-          scaffoldMessengerKey: snackbarKey,
-          localizationsDelegates: [
-            CroppyLocalizations.delegate,
-            FlutterI18nDelegate(
-              translationLoader: FileTranslationLoader(basePath: 'assets/i18n'),
-              missingTranslationHandler: (key, locale) {
-                GetIt.I.get<Logger>().e('Missing Key: $key, locale: $locale');
-              },
-            ),
-            ...AppLocalizations.localizationsDelegates,
-          ],
-          supportedLocales: AppLocalizations.supportedLocales,
-        ),
+    return Features(
+      child: MaterialApp.router(
+        routerConfig: _router,
+
+        debugShowCheckedModeBanner: false,
+        themeMode: themeSetting.themeMode,
+        theme: lightTheme,
+        darkTheme: themeSetting.amoled ? amoledTheme : darkTheme,
+        highContrastTheme: highContrastTheme,
+        highContrastDarkTheme: highContrastDarkTheme,
+        scaffoldMessengerKey: snackbarKey,
+        localizationsDelegates: [
+          CroppyLocalizations.delegate,
+          FlutterI18nDelegate(
+            translationLoader: FileTranslationLoader(basePath: 'assets/i18n'),
+            missingTranslationHandler: (key, locale) {
+              GetIt.I.get<Logger>().e('Missing Key: $key, locale: $locale');
+            },
+          ),
+          ...AppLocalizations.localizationsDelegates,
+        ],
+        supportedLocales: AppLocalizations.supportedLocales,
       ),
     );
   }

--- a/apps/enmeshed/lib/main.dart
+++ b/apps/enmeshed/lib/main.dart
@@ -517,6 +517,22 @@ class EnmeshedApp extends StatelessWidget with WatchItMixin {
           ...AppLocalizations.localizationsDelegates,
         ],
         supportedLocales: AppLocalizations.supportedLocales,
+        builder: (context, child) {
+          debugPrint(Theme.of(context).brightness.toString());
+
+          return AnnotatedRegion<SystemUiOverlayStyle>(
+            value: SystemUiOverlayStyle(
+              statusBarColor: Colors.transparent,
+              systemNavigationBarDividerColor: Colors.transparent,
+              systemNavigationBarColor: Colors.transparent,
+              systemNavigationBarContrastEnforced: false,
+              systemNavigationBarIconBrightness: Theme.of(context).brightness.opposite,
+              statusBarBrightness: Theme.of(context).brightness,
+              statusBarIconBrightness: Theme.of(context).brightness.opposite,
+            ),
+            child: child!,
+          );
+        },
       ),
     );
   }


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

When the AnnotatedRegion is too far up im the widget tree (in our case it was the first widget) it always gets the light setting and not the defined one.

With this PR the System UI reacts on System, Light and Dark properly.
