### PR TITLE
The device onboarding QR code is not visible in dark mode

### DIFF
--- a/apps/enmeshed/lib/profiles/device/modals/device_onboarding.dart
+++ b/apps/enmeshed/lib/profiles/device/modals/device_onboarding.dart
@@ -179,11 +179,11 @@ class _DeviceOnboardingQRCode extends StatelessWidget {
                     semanticsLabel: context.l10n.devices_code_qrSemanticsLabel,
                     eyeStyle: QrEyeStyle(
                       eyeShape: QrEyeShape.square,
-                      color: isExpired ? Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.2) : Theme.of(context).colorScheme.scrim,
+                      color: isExpired ? Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.2) : Theme.of(context).colorScheme.onSurface,
                     ),
                     dataModuleStyle: QrDataModuleStyle(
                       dataModuleShape: QrDataModuleShape.square,
-                      color: isExpired ? Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.2) : Theme.of(context).colorScheme.scrim,
+                      color: isExpired ? Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.2) : Theme.of(context).colorScheme.onSurface,
                     ),
                     size: 200,
                   ),


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description 
QR Code is black in dark mode and barely visible:
![Xnapper-2025-04-11-14 55 49](https://github.com/user-attachments/assets/09769e03-6c4c-4212-87f6-9c8efebc780a)

After fixing the color:
<img width="534" alt="Xnapper-2025-04-11-14 58 44" src="https://github.com/user-attachments/assets/56ca4ced-c778-400f-b051-8a0d00993d06" />
