### PR TITLE
Some tag translations are missing

### DIFF
--- a/apps/enmeshed/assets/i18n/de.json
+++ b/apps/enmeshed/assets/i18n/de.json
@@ -1221,9 +1221,9 @@
     "urn:xbildung-de:unesco:codeliste:isced2011=3": "Sekundarbereich II",
     "urn:xbildung-de:unesco:codeliste:isced2011=34": "Allgemeinbildend",
     "urn:xbildung-de:unesco:codeliste:isced2011=344": "Gymnasien (Oberstufe)",
-    "urn:xbildung-de:destatis:codeliste:artdesschulabschlusses=http://xbildung.de/def/destatis/1.0/code/artdesschulabschlusses/allgemeine_hochschulreife": "Allgemeine Hochschulreife",
-    "urn:xschule-digital:xschule:codeliste:zeugnisart=http://xschule.digital/def/xschule/0.5/code/zeugnisart/abschlusszeugnis": "Abschlusszeugnis",
-    "urn:xbildung-de:kmk:codeliste:artderschule=https://www.xbildung.de/def/kmk/kds/4.0/code/artderschule/100": "Gymnasium",
+    "urn:xbildung-de:destatis:codeliste:artdesschulabschlusses=http://xbildung%de/def/destatis/1%0/code/artdesschulabschlusses/allgemeine_hochschulreife": "Allgemeine Hochschulreife",
+    "urn:xschule-digital:xschule:codeliste:zeugnisart=http://xschule%digital/def/xschule/0%5/code/zeugnisart/abschlusszeugnis": "Abschlusszeugnis",
+    "urn:xbildung-de:kmk:codeliste:artderschule=https://www%xbildung%de/def/kmk/kds/4%0/code/artderschule/100": "Gymnasium",
     "urn:de:bund:destatis:bevoelkerungsstatistik:schluessel:bundesland=05": "Nordrhein-Westfalen"
   }
 }

--- a/apps/enmeshed/assets/i18n/en.json
+++ b/apps/enmeshed/assets/i18n/en.json
@@ -1221,9 +1221,9 @@
     "urn:xbildung-de:unesco:codeliste:isced2011=3": "Secondary level II",
     "urn:xbildung-de:unesco:codeliste:isced2011=34": "General education",
     "urn:xbildung-de:unesco:codeliste:isced2011=344": "Grammar schools (upper school)",
-    "urn:xbildung-de:destatis:codeliste:artdesschulabschlusses=http://xbildung.de/def/destatis/1.0/code/artdesschulabschlusses/allgemeine_hochschulreife": "General higher education entrance qualification",
-    "urn:xschule-digital:xschule:codeliste:zeugnisart=http://xschule.digital/def/xschule/0.5/code/zeugnisart/abschlusszeugnis": "Final certificate",
-    "urn:xbildung-de:kmk:codeliste:artderschule=https://www.xbildung.de/def/kmk/kds/4.0/code/artderschule/100": "Grammar school",
+    "urn:xbildung-de:destatis:codeliste:artdesschulabschlusses=http://xbildung%de/def/destatis/1%0/code/artdesschulabschlusses/allgemeine_hochschulreife": "General higher education entrance qualification",
+    "urn:xschule-digital:xschule:codeliste:zeugnisart=http://xschule%digital/def/xschule/0%5/code/zeugnisart/abschlusszeugnis": "Final certificate",
+    "urn:xbildung-de:kmk:codeliste:artderschule=https://www%xbildung%de/def/kmk/kds/4%0/code/artderschule/100": "Grammar school",
     "urn:de:bund:destatis:bevoelkerungsstatistik:schluessel:bundesland=05": "North Rhine-Westphalia"
   }
 }

--- a/apps/enmeshed/lib/account/my_data/file/file_detail_screen.dart
+++ b/apps/enmeshed/lib/account/my_data/file/file_detail_screen.dart
@@ -33,7 +33,7 @@ class _FileDetailScreenState extends State<FileDetailScreen> {
     super.initState();
 
     _fileDVO = widget.preLoadedFile;
-    _tags = widget.fileReferenceAttribute?.tags;
+    _tags = <String>{..._fileDVO?.tags ?? [], ...widget.preLoadedFile?.tags ?? []}.toList();
 
     if (_fileDVO == null) {
       _load();
@@ -276,7 +276,7 @@ class _TagLabel extends StatelessWidget {
       return TranslatedText(context.i18nTranslate('i18n://attributes.values.languages.${label.substring(9)}'), style: style);
     }
 
-    final i18nTranslatable = 'i18n://tags.$label';
+    final i18nTranslatable = 'i18n://tags.${label.replaceAll('.', '%')}';
     final translatedLabel = context.i18nTranslate(i18nTranslatable);
 
     if (translatedLabel != i18nTranslatable) return Text(translatedLabel, style: style);


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

i18n keys are split at dots (`.`). When the key includes dots like the three changed ones they cannot be found by the translation lib.

I replaced the dots with a random character (I thought why not use %).