### PR TITLE
Move extension back to request item renderer lib

### DIFF
--- a/packages/enmeshed_ui_kit/lib/src/utils/extensions.dart
+++ b/packages/enmeshed_ui_kit/lib/src/utils/extensions.dart
@@ -1,4 +1,3 @@
-import 'package:enmeshed_types/enmeshed_types.dart';
 import 'package:flutter/material.dart';
 
 import 'custom_colors.dart';
@@ -9,8 +8,4 @@ extension GetCustomColors on BuildContext {
 
 extension BrightnessOpposite on Brightness {
   Brightness get opposite => this == Brightness.light ? Brightness.dark : Brightness.light;
-}
-
-extension InitiallyCheckedExtension on RequestItemDVODerivation {
-  bool get initiallyChecked => mustBeAccepted && requireManualDecision != true;
 }

--- a/packages/enmeshed_ui_kit/pubspec.yaml
+++ b/packages/enmeshed_ui_kit/pubspec.yaml
@@ -7,7 +7,6 @@ environment:
   flutter: ">=3.32.0"
 
 dependencies:
-  enmeshed_types: ^1.0.0
   flex_seed_scheme: ^3.5.1
   flutter:
     sdk: flutter

--- a/packages/renderers/lib/src/request/request_item_renderer/authentication_request_item_renderer.dart
+++ b/packages/renderers/lib/src/request/request_item_renderer/authentication_request_item_renderer.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 
 import '../request_item_index.dart';
 import '../request_renderer_controller.dart';
+import 'extensions/extensions.dart';
 import 'widgets/validation_error_box.dart';
 
 class AuthenticationRequestItemRenderer extends StatefulWidget {

--- a/packages/renderers/lib/src/request/request_item_renderer/consent_request_item_renderer.dart
+++ b/packages/renderers/lib/src/request/request_item_renderer/consent_request_item_renderer.dart
@@ -9,6 +9,7 @@ import 'package:i18n_translated_text/i18n_translated_text.dart';
 import '../../abstract_url_launcher.dart';
 import '../request_item_index.dart';
 import '../request_renderer_controller.dart';
+import 'extensions/extensions.dart';
 import 'widgets/validation_error_box.dart';
 
 class ConsentRequestItemRenderer extends StatefulWidget {

--- a/packages/renderers/lib/src/request/request_item_renderer/decidable/decidable_create_attribute_request_item.dart
+++ b/packages/renderers/lib/src/request/request_item_renderer/decidable/decidable_create_attribute_request_item.dart
@@ -1,10 +1,10 @@
 import 'package:enmeshed_types/enmeshed_types.dart';
-import 'package:enmeshed_ui_kit/enmeshed_ui_kit.dart';
 import 'package:flutter/widgets.dart';
 
 import '/src/attribute/draft_attribute_renderer.dart';
 import '../../request_item_index.dart';
 import '../../request_renderer_controller.dart';
+import '../extensions/extensions.dart';
 import 'checkbox_enabled_extension.dart';
 import 'widgets/handle_checkbox_change.dart';
 

--- a/packages/renderers/lib/src/request/request_item_renderer/decidable/decidable_propose_attribute_request_item_renderer.dart
+++ b/packages/renderers/lib/src/request/request_item_renderer/decidable/decidable_propose_attribute_request_item_renderer.dart
@@ -1,11 +1,11 @@
 import 'package:enmeshed_types/enmeshed_types.dart';
-import 'package:enmeshed_ui_kit/enmeshed_ui_kit.dart';
 import 'package:flutter/material.dart';
 
 import '/src/attribute/attribute_renderer.dart';
 import '../../open_attribute_switcher_function.dart';
 import '../../request_item_index.dart';
 import '../../request_renderer_controller.dart';
+import '../extensions/extensions.dart';
 import 'checkbox_enabled_extension.dart';
 
 class DecidableProposeAttributeRequestItemRenderer extends StatefulWidget {

--- a/packages/renderers/lib/src/request/request_item_renderer/decidable/decidable_read_attribute_request_item_renderer.dart
+++ b/packages/renderers/lib/src/request/request_item_renderer/decidable/decidable_read_attribute_request_item_renderer.dart
@@ -1,10 +1,10 @@
 import 'package:enmeshed_types/enmeshed_types.dart';
-import 'package:enmeshed_ui_kit/enmeshed_ui_kit.dart';
 import 'package:flutter/material.dart';
 import 'package:renderers/renderers.dart';
 import 'package:value_renderer/value_renderer.dart';
 
 import '../../request_item_index.dart';
+import '../extensions/extensions.dart';
 import 'checkbox_enabled_extension.dart';
 import 'widgets/processed_query_renderer.dart';
 

--- a/packages/renderers/lib/src/request/request_item_renderer/decidable/decidable_register_attribute_listener_request_item_renderer.dart
+++ b/packages/renderers/lib/src/request/request_item_renderer/decidable/decidable_register_attribute_listener_request_item_renderer.dart
@@ -1,10 +1,10 @@
 import 'package:enmeshed_types/enmeshed_types.dart';
-import 'package:enmeshed_ui_kit/enmeshed_ui_kit.dart';
 import 'package:flutter/material.dart';
 
 import '../../../custom_list_tile.dart';
 import '../../request_item_index.dart';
 import '../../request_renderer_controller.dart';
+import '../extensions/extensions.dart';
 import 'checkbox_enabled_extension.dart';
 import 'widgets/handle_checkbox_change.dart';
 

--- a/packages/renderers/lib/src/request/request_item_renderer/decidable/decidable_share_attribute_request_item_renderer.dart
+++ b/packages/renderers/lib/src/request/request_item_renderer/decidable/decidable_share_attribute_request_item_renderer.dart
@@ -1,10 +1,10 @@
 import 'package:enmeshed_types/enmeshed_types.dart';
-import 'package:enmeshed_ui_kit/enmeshed_ui_kit.dart';
 import 'package:flutter/widgets.dart';
 
 import '/src/attribute/draft_attribute_renderer.dart';
 import '../../request_item_index.dart';
 import '../../request_renderer_controller.dart';
+import '../extensions/extensions.dart';
 import 'checkbox_enabled_extension.dart';
 import 'widgets/handle_checkbox_change.dart';
 

--- a/packages/renderers/lib/src/request/request_item_renderer/extensions/extensions.dart
+++ b/packages/renderers/lib/src/request/request_item_renderer/extensions/extensions.dart
@@ -1,0 +1,5 @@
+import 'package:enmeshed_types/enmeshed_types.dart';
+
+extension InitiallyCheckedExtension on RequestItemDVODerivation {
+  bool get initiallyChecked => mustBeAccepted && requireManualDecision != true;
+}

--- a/packages/renderers/lib/src/request/request_item_renderer/free_text_request_item_renderer.dart
+++ b/packages/renderers/lib/src/request/request_item_renderer/free_text_request_item_renderer.dart
@@ -1,10 +1,10 @@
 import 'package:enmeshed_types/enmeshed_types.dart';
-import 'package:enmeshed_ui_kit/enmeshed_ui_kit.dart';
 import 'package:flutter/material.dart';
 
 import '../../custom_list_tile.dart';
 import '../request_item_index.dart';
 import '../request_renderer_controller.dart';
+import 'extensions/extensions.dart';
 
 class FreeTextRequestItemRenderer extends StatefulWidget {
   final FreeTextRequestItemDVO item;

--- a/packages/renderers/lib/src/request/request_item_renderer/transfer_file_ownership_request_item_renderer.dart
+++ b/packages/renderers/lib/src/request/request_item_renderer/transfer_file_ownership_request_item_renderer.dart
@@ -6,6 +6,7 @@ import 'package:i18n_translated_text/i18n_translated_text.dart';
 
 import '../request_item_index.dart';
 import '../request_renderer_controller.dart';
+import 'extensions/extensions.dart';
 import 'widgets/manual_decision_required.dart';
 import 'widgets/validation_error_box.dart';
 


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

The UI Kit depending on enmeshed_types makes it unnecessarily hard for the admin ui in the backbone repo to consume the ui kit.