### PR TITLE
Exprort app data is failing for recently installed apps

### DIFF
--- a/apps/enmeshed/lib/drawer/debug_screen.dart
+++ b/apps/enmeshed/lib/drawer/debug_screen.dart
@@ -142,9 +142,9 @@ class DebugScreen extends StatelessWidget {
     final logsDir = Directory('${dir.path}/logs');
     if (logsDir.existsSync()) await encoder.addDirectory(logsDir);
 
-    await encoder.addFile(File('${dir.path}/config.json'));
+    encoder.addArchiveFile(ArchiveFile.string('config.json', jsonEncode(runtime.runtimeConfigMap)));
 
-    encoder.closeSync();
+    await encoder.close();
 
     final bytes = zipFile.readAsBytesSync();
 

--- a/packages/enmeshed_runtime_bridge/lib/src/enmeshed_runtime.dart
+++ b/packages/enmeshed_runtime_bridge/lib/src/enmeshed_runtime.dart
@@ -166,30 +166,29 @@ class EnmeshedRuntime with WidgetsBindingObserver {
       callback: (_) => _runtimeReadyCompleter.completeError(Exception('Runtime init failed')),
     );
 
-    controller.addJavaScriptHandler(
-      handlerName: 'getRuntimeConfig',
-      callback: (_) => {
-        'applicationId': runtimeConfig.applicationId,
-        if (Platform.isIOS || Platform.isMacOS) 'applePushEnvironment': runtimeConfig.useAppleSandbox ? 'Development' : 'Production',
-        if (Platform.isIOS || Platform.isMacOS) 'pushService': 'apns' else if (Platform.isAndroid) 'pushService': 'fcm' else 'pushService': 'none',
-        'transportLibrary': {
-          'baseUrl': runtimeConfig.baseUrl,
-          'platformClientId': runtimeConfig.clientId,
-          'platformClientSecret': runtimeConfig.clientSecret,
-        },
-        'databaseFolder': runtimeConfig.databaseFolder,
-        'modules': {
-          if (Platform.isWindows) 'pushNotification': {'enabled': false},
-          if (Platform.isWindows) 'sse': {'enabled': true},
-          'decider': ?runtimeConfig.deciderModuleConfig,
-        },
-      },
-    );
+    controller.addJavaScriptHandler(handlerName: 'getRuntimeConfig', callback: (_) => runtimeConfigMap);
 
     controller.addJavaScriptHandler(handlerName: 'getAppLanguage', callback: (_) => WidgetsBinding.instance.platformDispatcher.locale.languageCode);
 
     await controller.addLocalNotificationsJavaScriptHandlers(runtimeConfig.androidNotificationColor);
   }
+
+  Map<String, dynamic> get runtimeConfigMap => {
+    'applicationId': runtimeConfig.applicationId,
+    if (Platform.isIOS || Platform.isMacOS) 'applePushEnvironment': runtimeConfig.useAppleSandbox ? 'Development' : 'Production',
+    if (Platform.isIOS || Platform.isMacOS) 'pushService': 'apns' else if (Platform.isAndroid) 'pushService': 'fcm' else 'pushService': 'none',
+    'transportLibrary': {
+      'baseUrl': runtimeConfig.baseUrl,
+      'platformClientId': runtimeConfig.clientId,
+      'platformClientSecret': runtimeConfig.clientSecret,
+    },
+    'databaseFolder': runtimeConfig.databaseFolder,
+    'modules': {
+      if (Platform.isWindows) 'pushNotification': {'enabled': false},
+      if (Platform.isWindows) 'sse': {'enabled': true},
+      'decider': ?runtimeConfig.deciderModuleConfig,
+    },
+  };
 
   /// Register the [UIBridge] to communicate with the native UI.
   /// This must be called after the runtime is ready.


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

The file config.json is not written to the storage anymore. This causes that is's not possible to export the app data anymore.