### PR TITLE
Melos integration test script is not referencing the config from the correct path

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -20,7 +20,7 @@ scripts:
     description: Run `flutter test` in all packages
 
   integration_test:
-    run: melos exec --dir-exists=integration_test --flutter -- "flutter test --dart-define-from-file=../../config.json integration_test/suite_test.dart"
+    run: melos exec --dir-exists=integration_test --flutter -- "flutter test --dart-define-from-file=../../../config.json integration_test/suite_test.dart"
     description: Run `integration tests` in all packages that have the folder `integration_test``
 
   outdated:


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

<!-- # Description -->
