### PR TITLE
Download file operation can be destroyed until the next app restart when using multiple file operations in the same time

### DIFF
--- a/apps/enmeshed/lib/account/my_data/file/file_detail_screen.dart
+++ b/apps/enmeshed/lib/account/my_data/file/file_detail_screen.dart
@@ -150,19 +150,19 @@ class _FileDetailScreenState extends State<FileDetailScreen> {
                           spacing: 8,
                           children: [
                             IconButton(
-                              onPressed: _isSharingFile || DateTime.parse(_fileDVO!.expiresAt).isBefore(DateTime.now()) ? null : _shareFile,
+                              onPressed: _preventFileOperation ? null : _shareFile,
                               icon: _isSharingFile
                                   ? const SizedBox(width: 28, height: 28, child: CircularProgressIndicator(strokeWidth: 3))
                                   : const Icon(Icons.share_outlined, size: 24),
                             ),
                             IconButton(
-                              onPressed: _isLoadingFile || DateTime.parse(_fileDVO!.expiresAt).isBefore(DateTime.now()) ? null : _downloadAndSaveFile,
+                              onPressed: _preventFileOperation ? null : _downloadAndSaveFile,
                               icon: _isLoadingFile
                                   ? const SizedBox(width: 28, height: 28, child: CircularProgressIndicator(strokeWidth: 3))
                                   : const Icon(Icons.file_download_outlined, size: 28),
                             ),
                             IconButton(
-                              onPressed: _isOpeningFile || DateTime.parse(_fileDVO!.expiresAt).isBefore(DateTime.now()) ? null : _openFile,
+                              onPressed: _preventFileOperation ? null : _openFile,
                               icon: _isOpeningFile
                                   ? const SizedBox(width: 28, height: 28, child: CircularProgressIndicator(strokeWidth: 3))
                                   : const Icon(Icons.file_open_outlined, size: 24),

--- a/apps/enmeshed/lib/account/my_data/file/file_detail_screen.dart
+++ b/apps/enmeshed/lib/account/my_data/file/file_detail_screen.dart
@@ -29,6 +29,9 @@ class _FileDetailScreenState extends State<FileDetailScreen> {
   bool _isLoadingFile = false;
   bool _isOpeningFile = false;
 
+  bool get _preventFileOperation =>
+      _isSharingFile || _isLoadingFile || _isOpeningFile || DateTime.parse(_fileDVO!.expiresAt).isBefore(DateTime.now());
+
   @override
   void initState() {
     super.initState();


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

It seems like mutliple of those OS operations can cause a deadlock.