### PR TITLE
Created attribute is not used in ReadAttributeRequestItemRenderer

### DIFF
--- a/packages/renderers/lib/src/request/request_item_renderer/read_attribute_request_item_renderer.dart
+++ b/packages/renderers/lib/src/request/request_item_renderer/read_attribute_request_item_renderer.dart
@@ -176,7 +176,9 @@ class _ReadAttributeRequestItemRendererState extends State<ReadAttributeRequestI
 
     widget.controller?.writeAtIndex(
       index: widget.itemIndex,
-      value: AcceptReadAttributeRequestItemParametersWithExistingAttribute(existingAttributeId: choice.id!),
+      value: choice.id == null
+          ? AcceptReadAttributeRequestItemParametersWithNewAttribute(newAttribute: choice.attribute)
+          : AcceptReadAttributeRequestItemParametersWithExistingAttribute(existingAttributeId: choice.id!),
     );
   }
 
@@ -201,7 +203,9 @@ class _ReadAttributeRequestItemRendererState extends State<ReadAttributeRequestI
 
     widget.controller?.writeAtIndex(
       index: widget.itemIndex,
-      value: AcceptReadAttributeRequestItemParametersWithExistingAttribute(existingAttributeId: choice.id!),
+      value: choice.id == null
+          ? AcceptReadAttributeRequestItemParametersWithNewAttribute(newAttribute: choice.attribute)
+          : AcceptReadAttributeRequestItemParametersWithExistingAttribute(existingAttributeId: choice.id!),
     );
   }
 
@@ -220,7 +224,9 @@ class _ReadAttributeRequestItemRendererState extends State<ReadAttributeRequestI
 
     widget.controller?.writeAtIndex(
       index: widget.itemIndex,
-      value: AcceptReadAttributeRequestItemParametersWithExistingAttribute(existingAttributeId: choice.id!),
+      value: choice.id == null
+          ? AcceptReadAttributeRequestItemParametersWithNewAttribute(newAttribute: choice.attribute)
+          : AcceptReadAttributeRequestItemParametersWithExistingAttribute(existingAttributeId: choice.id!),
     );
   }
 

--- a/packages/renderers/lib/src/request/request_item_renderer/read_attribute_request_item_renderer.dart
+++ b/packages/renderers/lib/src/request/request_item_renderer/read_attribute_request_item_renderer.dart
@@ -199,8 +199,6 @@ class _ReadAttributeRequestItemRendererState extends State<ReadAttributeRequestI
       _isChecked = true;
     });
 
-    if (choice.id != null) throw Exception('Choice should not have an ID when updating an attribute');
-
     widget.controller?.writeAtIndex(
       index: widget.itemIndex,
       value: AcceptReadAttributeRequestItemParametersWithExistingAttribute(existingAttributeId: choice.id!),


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

The logic was wrong and we ran into throw every time. I updated it to be more flexible (and prepared for my changes regarding relationship attributes, which currently don't work at all)..