### PR TITLE
Update mac build machine

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -67,7 +67,8 @@ workflows:
   ios-release:
     name: iOS Release
     max_build_duration: 40
-    instance_type: mac_mini_m1
+    instance_type: mac_mini_m2
+
     integrations:
       app_store_connect: codemagic
     triggering:

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -68,7 +68,6 @@ workflows:
     name: iOS Release
     max_build_duration: 40
     instance_type: mac_mini_m2
-
     integrations:
       app_store_connect: codemagic
     triggering:


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

The following warning is logged:

```txt
Warning: Mac mini M1 machines are no longer available, running the build on Mac mini M2 instead.
Mac mini M2 machines are provided for the same price as Mac mini M1.
Please change the instance type in your build configuration to hide the warning
```

This is not a big deal, but it feels safer to not have this warning logged in every build.